### PR TITLE
Fixes for loading texts and opt-out button bug

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -83,3 +83,7 @@ screen.message.common.tooltip.preference.ldap=Synchronize an individual’s memb
 screen.message.common.preference.sync.warning=Please be thoughtful about any changes here, some changes are operationally expensive.  Note that in extreme cases a requested change may take several hours.
 screen.message.membership.empty.optIn=No groupings are currently available.
 screen.message.membership.empty.membersList=No groupings are currently available.
+## Loading tooltips
+screen.message.common.loading.gettingmembers=Getting Members...
+screen.message.common.loading.loadcomplete=Members Loaded ✓
+screen.message.common.loading.toolarge=This Grouping is Too Large. Getting Members Stopped.

--- a/src/main/resources/static/css/colors.css
+++ b/src/main/resources/static/css/colors.css
@@ -157,7 +157,7 @@ h3{
 }
 
 .loading-text{
-    margin-left: 4.357em;
+    margin-left: 2.357em;
     color: #296191;
     float: left;
 }

--- a/src/main/resources/static/javascript/mainApp/membership.controller.js
+++ b/src/main/resources/static/javascript/mainApp/membership.controller.js
@@ -1,95 +1,96 @@
 (function () {
 
+  /**
+   * Controller for the memberships page.
+   * @param $scope - binding between controller and HTML page
+   * @param $window - the browser window object
+   * @param $controller - the service for instantiating controllers
+   * @param dataProvider - service that handles redirection to the feedback page upon error
+   * @param groupingsService - service for creating requests to the groupings API
+   */
+  function MembershipJsController($scope, $window, $controller, groupingsService, dataProvider) {
+
+    $scope.membershipsList = [];
+    $scope.pagedItemsMemberships = [];
+    $scope.currentPageMemberships = 0;
+
+    $scope.optInList = [];
+    $scope.pagedItemsOptInList = [];
+    $scope.currentPageOptIn = 0;
+
+    $scope.loading = false;
+
+    angular.extend(this, $controller("TableJsController", {$scope: $scope}));
+    angular.extend(this, $controller("TimeoutJsController", {$scope: $scope}));
+
     /**
-     * Controller for the memberships page.
-     * @param $scope - binding between controller and HTML page
-     * @param $window - the browser window object
-     * @param $controller - the service for instantiating controllers
-     * @param dataProvider - service that handles redirection to the feedback page upon error
-     * @param groupingsService - service for creating requests to the groupings API
+     * Loads the groups the user is a member in, the groups the user is able to opt in to, and the groups the user
+     * is able to opt out of.
      */
-    function MembershipJsController($scope, $window, $controller, groupingsService, dataProvider) {
+    $scope.init = function () {
+      $scope.loading = true;
 
-        $scope.membershipsList = [];
-        $scope.pagedItemsMemberships = [];
-        $scope.currentPageMemberships = 0;
+      groupingsService.getMembershipAssignment(function (res) {
+        $scope.membershipsList = _.sortBy(res.groupingsIn, "name");
+        $scope.filter($scope.membershipsList, "pagedItemsMemberships", "currentPageMemberships", $scope.membersQuery, true);
 
-        $scope.optInList = [];
-        $scope.pagedItemsOptInList = [];
-        $scope.currentPageOptIn = 0;
+        $scope.optInList = _.sortBy(res.groupingsToOptInTo, "name");
+        $scope.filter($scope.optInList, "pagedItemsOptInList", "currentPageOptIn", $scope.optInQuery, true);
 
         $scope.loading = false;
+      }, function (res) {
+        dataProvider.handleException({exceptionMessage: res.exceptionMessage}, "feedback/error", "feedback");
+      });
+    };
 
-        angular.extend(this, $controller("TableJsController", { $scope: $scope }));
-        angular.extend(this, $controller("TimeoutJsController", { $scope: $scope }));
-
-        /**
-         * Loads the groups the user is a member in, the groups the user is able to opt in to, and the groups the user
-         * is able to opt out of.
-         */
-        $scope.init = function () {
-            $scope.loading = true;
-
-            groupingsService.getMembershipAssignment(function (res) {
-                $scope.membershipsList = _.sortBy(res.groupingsIn, "name");
-                $scope.filter($scope.membershipsList, "pagedItemsMemberships", "currentPageMemberships", $scope.membersQuery, true);
-
-                $scope.optInList = _.sortBy(res.groupingsToOptInTo, "name");
-                $scope.filter($scope.optInList, "pagedItemsOptInList", "currentPageOptIn", $scope.optInQuery, true);
-
-                $scope.loading = false;
-            }, function (res) {
-                dataProvider.handleException({ exceptionMessage: res.exceptionMessage }, "feedback/error", "feedback");
-            });
-        };
-
-        /**
-         * Handles responses for opting into or out of a grouping.
-         * @param {object} res - the response from opting into/out of a grouping
-         */
-        function handleSuccessfulOpt(res) {
-            if (_.startsWith(res[0].resultCode, "SUCCESS")) {
-                $scope.init();
-            }
-        }
-
-        /**
-         * Generic handler for an unsuccessful opt into/out of a grouping.
-         * @param {object} res - the response from the request
-         */
-        function handleUnsuccessfulOpt(res) {
-            console.log("Error opting into grouping: " + res.statusCode);
-        }
-
-        /**
-         * Adds the user to the exclude group of the grouping selected. Sends back an alert saying if it failed.
-         * @param {number} currentPage - the current page within the table
-         * @param {number} indexClicked - the index of the grouping clicked by the user
-         */
-        $scope.optOut = function (currentPage, indexClicked) {
-            const groupingPath = $scope.pagedItemsMemberships[currentPage][indexClicked].path;
-            $scope.loading = true;
-            groupingsService.optOut(groupingPath, handleSuccessfulOpt, handleUnsuccessfulOpt);
-        };
-
-        /**
-         * Adds the user to the include group of the grouping selected.
-         * @param {number} currentPage - the current page within the table
-         * @param {number} indexClicked - the index of the grouping clicked by the user
-         */
-        /*   $scope.optIn = function (currentPage, indexClicked) {
-         const groupingPath = $scope.pagedItemsOptInList[currentPage][indexClicked].path;
-         $scope.loading = true;
-         groupingsService.optIn(groupingPath, handleSuccessfulOpt, handleUnsuccessfulOpt);
-         };*/
-
-        $scope.optIn = function (currentPage, indexClicked) {
-            const groupingPath = $scope.pagedItemsOptInList(currentPage * indexClicked).path;
-            $scope.loading = true;
-            groupingsService.optIn(groupingPath, handleSuccessfulOpt, handleUnsuccessfulOpt);
-        };
+    /**
+     * Handles responses for opting into or out of a grouping.
+     * @param {object} res - the response from opting into/out of a grouping
+     */
+    function handleSuccessfulOpt(res) {
+      if (_.startsWith(res[0].resultCode, "SUCCESS")) {
+        $scope.init();
+      }
     }
 
-    UHGroupingsApp.controller("MembershipJsController", MembershipJsController);
+    /**
+     * Generic handler for an unsuccessful opt into/out of a grouping.
+     * @param {object} res - the response from the request
+     */
+    function handleUnsuccessfulOpt(res) {
+      console.log("Error opting into grouping: " + res.statusCode);
+    }
+
+    /**
+     * Adds the user to the exclude group of the grouping selected. Sends back an alert saying if it failed.
+     * @param {number} currentPage - the current page within the table
+     * @param {number} indexClicked - the index of the grouping clicked by the user
+     */
+    $scope.optOut = function (currentPage, indexClicked) {
+      const groupingPath = $scope.pagedItemsMemberships[currentPage][indexClicked].path;
+      $scope.loading = true;
+      groupingsService.optOut(groupingPath, handleSuccessfulOpt, handleUnsuccessfulOpt);
+    };
+
+    /**
+     * Adds the user to the include group of the grouping selected.
+     * @param {number} currentPage - the current page within the table
+     * @param {number} indexClicked - the index of the grouping clicked by the user
+     */
+    /*   $scope.optIn = function (currentPage, indexClicked) {
+     const groupingPath = $scope.pagedItemsOptInList[currentPage][indexClicked].path;
+     $scope.loading = true;
+     groupingsService.optIn(groupingPath, handleSuccessfulOpt, handleUnsuccessfulOpt);
+     };*/
+
+    $scope.optIn = function (currentPage, indexClicked) {
+      // const groupingPath = $scope.pagedItemsOptInList(currentPage * indexClicked).path;
+      const groupingPath = $scope.pagedItemsOptInList[currentPage][indexClicked].path;
+      $scope.loading = true;
+      groupingsService.optIn(groupingPath, handleSuccessfulOpt, handleUnsuccessfulOpt);
+    };
+  }
+
+  UHGroupingsApp.controller("MembershipJsController", MembershipJsController);
 
 })();

--- a/src/main/resources/templates/fragments/basis.html
+++ b/src/main/resources/templates/fragments/basis.html
@@ -5,14 +5,14 @@
             <h3>Basis<span> ({{groupingBasis.length}})</span></h3>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingProgress">
-            <h4 class="loading-text">Now Loading...</h4>
+            <h4 class="loading-text" th:text="#{screen.message.common.loading.gettingmembers}"></h4>
             <div class="small-loader"></div>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingComplete">
-            <h4 class="done-text">Grouping Loaded! ✓</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.loadcomplete}"></h4>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="largeGrouping">
-            <h4 class="done-text">Grouping Too Large. Loading stopped.</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.toolarge}"></h4>
         </div>
     </div>
 

--- a/src/main/resources/templates/fragments/exclude.html
+++ b/src/main/resources/templates/fragments/exclude.html
@@ -5,14 +5,14 @@
             <h3>Exclude<span> ({{groupingExclude.length}})</span></h3>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingProgress">
-            <h4 class="loading-text">Now Loading...</h4>
+            <h4 class="loading-text" th:text="#{screen.message.common.loading.gettingmembers}"></h4>
             <div class="small-loader"></div>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingComplete">
-            <h4 class="done-text">Grouping Loaded! ✓</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.loadcomplete}"></h4>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="largeGrouping">
-            <h4 class="done-text">Grouping Too Large. Loading stopped.</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.toolarge}"></h4>
         </div>
     </div>
 

--- a/src/main/resources/templates/fragments/include.html
+++ b/src/main/resources/templates/fragments/include.html
@@ -5,14 +5,14 @@
             <h3>Include<span> ({{groupingInclude.length}})</span></h3>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingProgress">
-            <h4 class="loading-text">Now Loading...</h4>
+            <h4 class="loading-text" th:text="#{screen.message.common.loading.gettingmembers}"></h4>
             <div class="small-loader"></div>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingComplete">
-            <h4 class="done-text">Grouping Loaded! ✓</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.loadcomplete}"></h4>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="largeGrouping">
-            <h4 class="done-text">Grouping Too Large. Loading stopped.</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.toolarge}"></h4>
         </div>
     </div>
 

--- a/src/main/resources/templates/fragments/members.html
+++ b/src/main/resources/templates/fragments/members.html
@@ -5,14 +5,14 @@
             <h3>All Members<span> ({{groupingMembers.length}})</span></h3>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingProgress">
-            <h4 class="loading-text">Now Loading...</h4>
+            <h4 class="loading-text" th:text="#{screen.message.common.loading.gettingmembers}"></h4>
             <div class="small-loader"></div>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingComplete">
-            <h4 class="done-text">Grouping Loaded! ✓</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.loadcomplete}"></h4>
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="largeGrouping">
-            <h4 class="done-text">Grouping Too Large. Loading stopped.</h4>
+            <h4 class="done-text" th:text="#{screen.message.common.loading.toolarge}"></h4>
         </div>
     </div>
 

--- a/src/main/resources/templates/fragments/owners.html
+++ b/src/main/resources/templates/fragments/owners.html
@@ -4,13 +4,6 @@
         <div class="col-lg-9 col-md-8 col-sm-6 col-12 p-0 mb-sm-0 mb-2">
             <h3>Owners<span> ({{groupingOwners.length}})</span></h3>
         </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingProgress">
-            <h4 class="loading-text">Now Loading...</h4>
-            <div class="small-loader"></div>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="largeGrouping">
-            <h4 class="done-text">Grouping Too Large. Loading stopped.</h4>
-        </div>
     </div>
 
     <div class="table-responsive-sm">

--- a/src/main/resources/templates/fragments/preferences.html
+++ b/src/main/resources/templates/fragments/preferences.html
@@ -3,13 +3,6 @@
         <div class="col-lg-9 col-md-8 col-sm-6 col-12 p-0 mb-sm-0 mb-2">
             <h3>Preferences</h3>
         </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="paginatingProgress">
-            <h4 class="loading-text">Now Loading...</h4>
-            <div class="small-loader"></div>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 col-12" ng-show="largeGrouping">
-            <h4 class="done-text">Grouping Too Large. Loading stopped.</h4>
-        </div>
     </div>    <div class="card">
         <div class="card-body">
             <div class="row">


### PR DESCRIPTION
- Fixed opt-out button bug, should function properly again.
- Moved loading texts from hard-coded strings to messages.properties file
- Removed loading texts from owners and preferences pages. I am aware Zak implemented this as well, his changes can overwrite what I did here when he merges, if he went into more detail with the functionality.