### PR TITLE
Changed groupings page to be more consistent with other pages

### DIFF
--- a/src/main/resources/templates/fragments/groupings-list.html
+++ b/src/main/resources/templates/fragments/groupings-list.html
@@ -1,6 +1,5 @@
 <th:block th:fragment="groupings-list">
     <div class="table-responsive-sm">
-        <th:classappend="${tabContent ? 'card-tab-content' : ''}">
         <table class="table manage-groupings table-striped table-hover" aria-live="assertive">
             <thead>
             <tr>
@@ -18,7 +17,7 @@
                     <i class="fa sort-icon" ng-show="columnSort.groupingsList.property === 'path'"
                        ng-class="{ reverse: columnSort.groupingsList.reverse }"></i>
                 </th>
-                <th> Opt Out?</th>
+                <th class="w-20 text-center"> Opt Out?</th>
             </tr>
             </thead>
             <tbody>
@@ -26,7 +25,9 @@
                 <td class="clickable" tabindex="0"
                     ng-keypress="$event.keyCode === 13 ? displayGrouping(currentPageGroupings, $index) : null"
                     ng-click="displayGrouping(currentPageGroupings, $index)">
-                    {{l.name}}
+                    <i class="fa fa-fw fa-pencil-square-o" aria-hidden="true"></i>
+
+                  {{l.name}}
                 </td>
                 <td>
 
@@ -43,19 +44,16 @@
                             <i class="fa fa-fw fa-clipboard" aria-hidden="true"></i></button>
                     </form>
                 </td>
-                <td>
-                         <span ng-if="l.optOutOn">
-                                    Membership Required
+                <td class="w-20">
+                    <span ng-if="l.optOutOn">
+                        Membership Required
                     </span>
-                    <div ng-if="!l.optOutOn">
-                        <button id="optOutButton"
-                                class="btn dark-teal-bg btn-primary text-center"
-                                tabindex="0"
-                                ng-click="optOut(currentPageGroupings, $index)">
-                            <i class="fa fa-fw fa-user-times" aria-hidden="true"></i>
-                            Opt Out
-                        </button>
-                    </div>
+                    <button class="btn btn-primary btn-block opt-button"
+                            tabindex="0"
+                            ng-click="optOut(currentPageGroupings, $index)">
+                        <i class="fa fa-fw fa-user-plus" aria-hidden="true"></i>
+                        Opt Out
+                    </button>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/groupings.html
+++ b/src/main/resources/templates/groupings.html
@@ -6,38 +6,40 @@
 <nav th:replace="menubar :: copy"></nav>
 
 <!--  Content container-->
-    <div class="seafoam-bg pt-0">
-        <div class="container">
-            <div class="row pt-5 pb-4">
-                <div class="col-lg-9 col-md-8 col-12">
-                    <h1 class="text-center text-md-left">Manage My Groupings</h1>
-                        <p class="lead text-center text-md-left" th:utext="#{screen.message.groupings.page.description}"></p>
-                </div>
-                <div class="col-lg-3 col-md-4 col-12">
-                    <input class="form-control" placeholder="Filter Groupings..." type="text"
-                           title="Filter Groupings"
-                           ng-model="groupingsQuery"
-                           ng-change="filter(groupingsList, 'pagedItemsGroupings', 'currentPageGroupings', groupingsQuery, true)"/>
-                </div>
-            </div>
-        </div>
-    </div>
+<div class="seafoam-bg pt-5">
+  <div class="container">
+    <h1 class="text-center text-md-left">Manage My Groupings</h1>
+    <p class="lead text-center text-md-left" th:utext="#{screen.message.groupings.page.description}"></p>
+  </div>
+</div>
 
 <div class="container">
-    <div id="overlay" ng-show="loading">
-        <div class="loader" ng-show="loading"></div>
-    </div>
-
-    <div class="nav-tabs nav-item">
-        <div ng-show="!showGrouping">
-            <div th:replace="fragments/groupings-list :: groupings-list"></div>
+  <div id="overlay" ng-show="loading">
+    <div class="loader" ng-show="loading"></div>
+  </div>
+  <div ng-show="!showGrouping">
+    <div class="tab-content">
+      <div class="tab-pane fade show active" id="manage-groupings" role="tabcard">
+        <div class="row m-auto pt-4 pb-4">
+          <div class="col-lg-9 col-md-8 col-12 p-0">
+            <h2 class="card-title mt-md-1 mt-0 mb-1">Manage Groupings</h2>
+          </div>
+          <div class="col-lg-3 col-md-4 col-12 p-0">
+            <input class="form-control" placeholder="Filter Groupings..." type="text"
+                   title="Filter Groupings"
+                   ng-model="groupingsQuery"
+                   ng-change="filter(groupingsList, 'pagedItemsGroupings', 'currentPageGroupings', groupingsQuery, true)"/>
+          </div>
         </div>
-
-        <div ng-show="showGrouping">
-            <div th:replace="fragments/selected-grouping :: selected-grouping(tabContent=true)"></div>
-<!--                <div th:replace="fragments/manage-grouping :: manage-grouping"></div>-->
-        </div>
+        <div th:replace="fragments/groupings-list :: groupings-list"></div>
+      </div>
+      <div class="tab-pane fade" id="placeholder" role=""></div>
     </div>
+  </div>
+
+  <div ng-show="showGrouping">
+    <div th:replace="fragments/selected-grouping :: selected-grouping(tabContent=true)"></div>
+  </div>
 </div>
 <!-- / Content container. -->
 </div>


### PR DESCRIPTION
Deleted unneeded html code, added icon for page consistency, added groupings list to be in a tab for consistency, dropped down the filter to match other pages, centered Opt out button and title so it is consistent with Memberships page, added a title above the groupings list table, and got rid of the thin gray lines above the pagination and right below the Manage My Groupings banner.