### PR TITLE
Realigning basis/include/exclude/owner tables for symmetry and page c…

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -354,11 +354,6 @@ table .p-10 {
     th.grouping-name {
         min-width: 10rem;
     }
-    /*.manage-groupings td span.path {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }*/
 }
 th {
     font-size: .8rem;
@@ -419,8 +414,6 @@ form.seamless button {
     height: 20px !important;
 }
 
-
-
 @media (max-width: 991.98px) {
     .tooltip {
         display: none;
@@ -439,10 +432,6 @@ form.seamless button {
     overflow: hidden;
 }
 
-/*.card.page-header {
-    margin-bottom: 1rem;
-}*/
-
 .nav-tabs .nav-item{
     margin-top: 1rem;
 }
@@ -458,7 +447,6 @@ form.seamless button {
 .text-tracking {
     letter-spacing: 1px;
 }
-
 
 .container {
     flex: 1;

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -60,7 +60,7 @@
                 </div>
                 <div class="table-responsive-sm">
                     <table class="table manage-admins table-striped table-hover table-md" aria-live="assertive">
-                        <thead class="align-middle">
+                        <thead>
                         <tr>
                             <th ng-click="sortBy('adminsList', 'pagedItemsAdmins', 'name')" class="clickable">
                                 Admin Name

--- a/src/main/resources/templates/fragments/basis.html
+++ b/src/main/resources/templates/fragments/basis.html
@@ -3,24 +3,34 @@
 
         <div class="row">
             <div class="col-md-8">
-                <h2 class="font-weight-bold text-dark pt-4">Basis ({{groupingBasis.length}})</h2>
+                <h1 class="font-weight-bold text-dark pt-2 mb-0">All Members ({{groupingMembers.length}})</h1>
+                <p class=" mb-1" style="display:inline-block" ng-show="paginatingProgress"
+                   th:text="#{screen.message.common.loading.gettingmembers}"></p>
+                <div class="spinner-border spinner-border-sm" style="display:inline-block"
+                     ng-hide="!paginatingProgress"
+                     role="status">
+                    <span class="sr-only">Loading...</span>
+                </div>
+                <p class=" mb-1" ng-show="paginatingComplete"
+                   th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check"
+                                                                              aria-hidden="true"></i></p>
+                <p class=" mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"><i
+                        class="fa fa-check" aria-hidden="true"></i></p>
+            </div>
+            <div class="col-md-4 pt-2">
+                <input placeholder="Filter Members..." type="text" title="Filter Members"
+                       ng-model="membersQuery" class="form-control"
+                       ng-change="filter(groupingMembers, 'pagedItemsMembers', 'currentPageMembers', membersQuery, true)"/>
                 <!-- Export to CSV button -->
-                <button class="btn btn-sm btn-primary mb-4" type="submit" ng-click="exportGroupToCsv(groupingBasis, selectedGrouping.name, 'basis')">
+                <button class="btn btn-sm btn-primary float-right mb-1 mt-1" type="submit"
+                        ng-click="exportGroupToCsv(groupingMembers, selectedGrouping.name, 'members')">
                     <i class="fa fa-refresh mr-2" aria-hidden="true"></i>
                     Export to CSV
                 </button>
             </div>
-            <div class="col-md-4">
-                <p class="pt-4 mb-1" ng-show="paginatingProgress" th:text="#{screen.message.common.loading.gettingmembers}"><i class="fa fa-spinner" aria-hidden="true"></i></p>
-                <p class="pt-4 mb-1" ng-show="paginatingComplete" th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check" aria-hidden="true"></i></p>
-                <p class="pt-4 mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"> <i class="fa fa-check" aria-hidden="true"></i></p>
-                <input placeholder="Filter Members..." type="text" title="Filter Members"
-                       ng-model="basisQuery" class="form-control"
-                       ng-change="filter(groupingBasis, 'pagedItemsBasis', 'currentPageBasis', basisQuery, true)"/>
-            </div>
         </div>
 
-        <div class="table-responsive">
+        <div class="table-responsive-sm">
             <table class="table table-striped table-hover" aria-live="assertive">
                 <thead>
                 <tr>
@@ -46,10 +56,10 @@
                 </tr>
                 </thead>
                 <tbody>
-                <tr ng-repeat="b in pagedItemsBasis[currentPageBasis]">
-                    <td>{{b.name}}</td>
-                    <td>{{b.uuid}}</td>
-                    <td>
+                <tr ng-repeat="b in pagedItemsBasis[currentPageBasis]" class="table table-sm">
+                    <td class="p-10">{{b.name}}</td>
+                    <td class="p-10">{{b.uuid}}</td>
+                    <td class="p-10">
                         {{b.username}}
                         <div ng-if="b.username === ''">
                             <span>N/A</span>

--- a/src/main/resources/templates/fragments/exclude.html
+++ b/src/main/resources/templates/fragments/exclude.html
@@ -1,117 +1,127 @@
 <th:block th:fragment="exclude">
 
-<div id="exclude" class="tab-pane fade show active">
+    <div id="exclude" class="tab-pane fade show active">
 
-    <div class="row">
-        <div class="col-md-8">
-            <h2 class="font-weight-bold text-dark pt-4">Exclude ({{groupingExclude.length}})</h2>
-            <!-- Export to CSV button -->
-            <button class="btn btn-sm btn-primary mb-4" type="submit" ng-click="exportGroupToCsv(groupingExclude, selectedGrouping.name, 'exclude')">
-                <i class="fa fa-refresh mr-2" aria-hidden="true"></i>
-                Export to CSV
-            </button>
-        </div>
-        <div class="col-md-4">
-            <p class="pt-4 mb-1" ng-show="paginatingProgress" th:text="#{screen.message.common.loading.gettingmembers}"><i class="fa fa-spinner" aria-hidden="true"></i></p>
-            <p class="pt-4 mb-1" ng-show="paginatingComplete" th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check" aria-hidden="true"></i></p>
-            <p class="pt-4 mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"> <i class="fa fa-check" aria-hidden="true"></i></p>
-            <input placeholder="Filter Members..." type="text" title="Filter Members"
-                   ng-model="excludeQuery" class="form-control"
-                   ng-change="filter(groupingExclude, 'pagedItemsExclude', 'currentPageExclude', excludeQuery, true)"/>
-        </div>
-    </div>
-
-    <div class="table-responsive">
-        <table class="table table-striped table-hover" aria-live="assertive">
-            <thead>
-            <tr>
-                <th scope="col" class="clickable"
-                    ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'name')">
-                    Name
-                    <i class="fa sort-icon"
-                       ng-show="columnSort.groupingExclude.property === 'name' || !columnSort.groupingExclude"
-                       ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
-                </th>
-                <th scope="col" class="clickable"
-                    ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'uuid')">
-                    UH Number
-                    <i class="fa sort-icon" ng-show="columnSort.groupingExclude.property === 'uuid'"
-                       ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
-                </th>
-                <th scope="col" class="clickable"
-                    ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'username')">
-                    UH Username
-                    <i class="fa sort-icon" ng-show="columnSort.groupingExclude.property === 'username'"
-                       ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
-                </th>
-                <th scope="col" class="basis-column clickable"
-                    ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'inBasis')">
-                    In Basis?
-                    <i class="fa sort-icon" ng-show="columnSort.groupingExclude.property === 'inBasis'"
-                       ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
-                </th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr ng-repeat="e in pagedItemsExclude[currentPageExclude]">
-                <td tabindex="0">
-                    {{e.name}}
-                    <span class="fa fa-trash-o pull-right clickable pt-1"
-                          data-toggle="tooltip" data-placement="top"
-                          onmouseover="$(this).tooltip('show')" onmouseout="$(this).tooltip('dispose')"
-                          tabindex="0"
-                          th:title="#{screen.message.common.tooltip.remove.exclude}"
-                          ng-keypress="$event.keyCode === 13 ? removeMember('Exclude', currentPageExclude, $index) : null"
-                          ng-click="removeMember('Exclude', currentPageExclude, $index)">
-                    </span>
-                </td>
-                <td>{{e.uuid}}</td>
-                <td>
-                    {{e.username}}
-                    <div ng-if="e.username === ''">
-                        <span>N/A</span>
-                        <i class="fa fa-question-circle clickable" aria-hidden="true"
-                           data-toggle="tooltip" data-placement="right"
-                           onmouseover="$(this).tooltip('show')" onmouseout="$(this).tooltip('dispose')"
-                           th:title="#{screen.message.common.tooltip.username.notApplicable}">
-                        </i>
-                    </div>
-                </td>
-                <td class="basis-column text-center">{{e.inBasis}}</td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
-    <div class="d-lg-flex d-block justify-content-lg-between justify-content-start">
-        <div class="col-lg-4 pl-0 pr-0 mt-lg-0 mt-2">
-            <form ng-submit="addMember('Exclude')">
-                <div class="input-group">
-                    <input class="form-control" type="text" placeholder="UH Username"
-                           title="Enter UH username to exclude"
-                           ng-model="userToAdd"/>
-
-                    <div class="input-group-append">
-                        <button class="btn btn-primary" type="submit">Add</button>
-                    </div>
+        <div class="row">
+            <div class="col-md-8">
+                <h1 class="font-weight-bold text-dark pt-2 mb-0">All Members ({{groupingMembers.length}})</h1>
+                <p class=" mb-1" style="display:inline-block" ng-show="paginatingProgress"
+                   th:text="#{screen.message.common.loading.gettingmembers}"></p>
+                <div class="spinner-border spinner-border-sm" style="display:inline-block"
+                     ng-hide="!paginatingProgress"
+                     role="status">
+                    <span class="sr-only">Loading...</span>
                 </div>
-            </form>
+                <p class=" mb-1" ng-show="paginatingComplete"
+                   th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check"
+                                                                              aria-hidden="true"></i></p>
+                <p class=" mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"><i
+                        class="fa fa-check" aria-hidden="true"></i></p>
+            </div>
+            <div class="col-md-4 pt-2">
+                <input placeholder="Filter Members..." type="text" title="Filter Members"
+                       ng-model="membersQuery" class="form-control"
+                       ng-change="filter(groupingMembers, 'pagedItemsMembers', 'currentPageMembers', membersQuery, true)"/>
+                <!-- Export to CSV button -->
+                <button class="btn btn-sm btn-primary float-right mb-1 mt-1" type="submit"
+                        ng-click="exportGroupToCsv(groupingMembers, selectedGrouping.name, 'members')">
+                    <i class="fa fa-refresh mr-2" aria-hidden="true"></i>
+                    Export to CSV
+                </button>
+            </div>
         </div>
-        <div class="mt-lg-0 mt-2">
-            <div th:replace="fragments/pagination :: pagination(currentPage ='currentPageExclude', pagedItems='pagedItemsExclude')"></div>
+
+        <div class="table-responsive">
+            <table class="table table-striped table-hover" aria-live="assertive">
+                <thead>
+                <tr>
+                    <th scope="col" class="clickable"
+                        ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'name')">
+                        Name
+                        <i class="fa sort-icon"
+                           ng-show="columnSort.groupingExclude.property === 'name' || !columnSort.groupingExclude"
+                           ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
+                    </th>
+                    <th scope="col" class="clickable"
+                        ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'uuid')">
+                        UH Number
+                        <i class="fa sort-icon" ng-show="columnSort.groupingExclude.property === 'uuid'"
+                           ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
+                    </th>
+                    <th scope="col" class="clickable"
+                        ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'username')">
+                        UH Username
+                        <i class="fa sort-icon" ng-show="columnSort.groupingExclude.property === 'username'"
+                           ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
+                    </th>
+                    <th scope="col" class="basis-column clickable"
+                        ng-click="sortBy('groupingExclude', 'pagedItemsExclude', 'inBasis')">
+                        Basis?
+                        <i class="fa sort-icon" ng-show="columnSort.groupingExclude.property === 'inBasis'"
+                           ng-class="{ reverse: columnSort.groupingExclude.reverse }"></i>
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr ng-repeat="e in pagedItemsExclude[currentPageExclude]" class="table table-sm">
+                    <td class="p-10" tabindex="0">
+                        {{e.name}}
+                        <span class="fa fa-trash-o pull-right clickable pt-1"
+                              data-toggle="tooltip" data-placement="top"
+                              onmouseover="$(this).tooltip('show')" onmouseout="$(this).tooltip('dispose')"
+                              tabindex="0"
+                              th:title="#{screen.message.common.tooltip.remove.exclude}"
+                              ng-keypress="$event.keyCode === 13 ? removeMember('Exclude', currentPageExclude, $index) : null"
+                              ng-click="removeMember('Exclude', currentPageExclude, $index)">
+                    </span>
+                    </td>
+                    <td class="p-10">{{e.uuid}}</td>
+                    <td class="p-10">
+                        {{e.username}}
+                        <div ng-if="e.username === ''">
+                            <span>N/A</span>
+                            <i class="fa fa-question-circle clickable" aria-hidden="true"
+                               data-toggle="tooltip" data-placement="right"
+                               onmouseover="$(this).tooltip('show')" onmouseout="$(this).tooltip('dispose')"
+                               th:title="#{screen.message.common.tooltip.username.notApplicable}">
+                            </i>
+                        </div>
+                    </td>
+                    <td class="basis-column text-center p-10">{{e.inBasis}}</td>
+                </tr>
+                </tbody>
+            </table>
         </div>
-    </div>
-    <div class="d-lg-flex d-block justify-content-lg-between justify-content-start">
-        <div>
-            <form ng-submit="addMembers('Exclude')">
-                <div class="input-group">
+        <div class="d-lg-flex d-block justify-content-lg-between justify-content-start">
+            <div class="col-lg-4 pl-0 pr-0 mt-lg-0 mt-2">
+                <form ng-submit="addMember('Exclude')">
+                    <div class="input-group">
+                        <input class="form-control" type="text" placeholder="UH Username"
+                               title="Enter UH username to exclude"
+                               ng-model="userToAdd"/>
+
+                        <div class="input-group-append">
+                            <button class="btn btn-primary" type="submit">Add</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="mt-lg-0 mt-2">
+                <div th:replace="fragments/pagination :: pagination(currentPage ='currentPageExclude', pagedItems='pagedItemsExclude')"></div>
+            </div>
+        </div>
+        <div class="d-lg-flex d-block justify-content-lg-between justify-content-start">
+            <div>
+                <form ng-submit="addMembers('Exclude')">
+                    <div class="input-group">
                     <textarea placeholder="Members to Add" class="form-control" rows="1" cols="15"
                               title="Enter multiple UH usernames to exclude" ng-model="usersToAdd"></textarea>
-                    <span class="input-group-append">
+                        <span class="input-group-append">
                     <button class="btn btn-primary" type="submit">Add Members</button>
                 </span>
-                </div>
-            </form>
+                    </div>
+                </form>
+            </div>
         </div>
     </div>
-</div>
 </th:block>

--- a/src/main/resources/templates/fragments/include.html
+++ b/src/main/resources/templates/fragments/include.html
@@ -5,25 +5,34 @@
 
         <div class="row">
             <div class="col-md-8">
-                <h2 class="font-weight-bold text-dark pt-4">Include ({{groupingInclude.length}})</h2>
+                <h1 class="font-weight-bold text-dark pt-2 mb-0">All Members ({{groupingMembers.length}})</h1>
+                <p class=" mb-1" style="display:inline-block" ng-show="paginatingProgress"
+                   th:text="#{screen.message.common.loading.gettingmembers}"></p>
+                <div class="spinner-border spinner-border-sm" style="display:inline-block"
+                     ng-hide="!paginatingProgress"
+                     role="status">
+                    <span class="sr-only">Loading...</span>
+                </div>
+                <p class=" mb-1" ng-show="paginatingComplete"
+                   th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check"
+                                                                              aria-hidden="true"></i></p>
+                <p class=" mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"><i
+                        class="fa fa-check" aria-hidden="true"></i></p>
+            </div>
+            <div class="col-md-4 pt-2">
+                <input placeholder="Filter Members..." type="text" title="Filter Members"
+                       ng-model="membersQuery" class="form-control"
+                       ng-change="filter(groupingMembers, 'pagedItemsMembers', 'currentPageMembers', membersQuery, true)"/>
                 <!-- Export to CSV button -->
-                <button class="btn btn-sm btn-primary mb-4" type="submit"
-                        ng-click="exportGroupToCsv(groupingInclude, selectedGrouping.name, 'include')">
+                <button class="btn btn-sm btn-primary float-right mb-1 mt-1" type="submit"
+                        ng-click="exportGroupToCsv(groupingMembers, selectedGrouping.name, 'members')">
                     <i class="fa fa-refresh mr-2" aria-hidden="true"></i>
                     Export to CSV
                 </button>
             </div>
-            <div class="col-md-4">
-                <p class="pt-4 mb-1" ng-show="paginatingProgress" th:text="#{screen.message.common.loading.gettingmembers}"><i class="fa fa-spinner" aria-hidden="true"></i></p>
-                <p class="pt-4 mb-1" ng-show="paginatingComplete" th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check" aria-hidden="true"></i></p>
-                <p class="pt-4 mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"> <i class="fa fa-check" aria-hidden="true"></i></p>
-                <input placeholder="Filter Members..." type="text" title="Filter Members"
-                       ng-model="includeQuery" class="form-control"
-                       ng-change="filter(groupingInclude, 'pagedItemsInclude', 'currentPageInclude', includeQuery, true)"/>
-            </div>
         </div>
 
-        <div class="table-responsive">
+        <div class="table-responsive-sm">
             <table class="table table-striped table-hover" aria-live="assertive">
                 <thead>
                 <tr>
@@ -48,15 +57,15 @@
                     </th>
                     <th scope="col" class="basis-column clickable"
                         ng-click="sortBy('groupingInclude', 'pagedItemsInclude', 'inBasis')">
-                        In Basis?
+                        Basis?
                         <i class="fa sort-icon" ng-show="columnSort.groupingInclude.property === 'inBasis'"
                            ng-class="{ reverse: columnSort.groupingInclude.reverse }"></i>
                     </th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr ng-repeat="i in pagedItemsInclude[currentPageInclude]">
-                    <td tabindex="0">
+                <tr ng-repeat="i in pagedItemsInclude[currentPageInclude]" class="table table-sm">
+                    <td class="p-10" tabindex="0">
                         {{i.name}}
                         <span class="fa fa-trash-o pull-right clickable pt-1"
                               data-toggle="tooltip" data-placement="top"
@@ -67,8 +76,8 @@
                               ng-click="removeMember('Include', currentPageInclude, $index)">
                         </span>
                     </td>
-                    <td>{{i.uuid}}</td>
-                    <td>
+                    <td class="p-10">{{i.uuid}}</td>
+                    <td class="p-10">
                         {{i.username}}
                         <div ng-if="i.username === ''">
                             <span>N/A</span>
@@ -79,7 +88,7 @@
                             </i>
                         </div>
                     </td>
-                    <td class="basis-column text-center">{{i.inBasis}}</td>
+                    <td class="basis-column text-center p-10">{{i.inBasis}}</td>
                 </tr>
                 </tbody>
             </table>

--- a/src/main/resources/templates/fragments/members.html
+++ b/src/main/resources/templates/fragments/members.html
@@ -4,25 +4,35 @@
 
         <div class="row">
             <div class="col-md-8">
-                <h2 class="font-weight-bold text-dark pt-4">All Members ({{groupingMembers.length}})</h2>
+                <h1 class="font-weight-bold text-dark pt-2 mb-0">All Members ({{groupingMembers.length}})</h1>
+                <p class=" mb-1" style="display:inline-block" ng-show="paginatingProgress"
+                   th:text="#{screen.message.common.loading.gettingmembers}"></p>
+                <div class="spinner-border spinner-border-sm" style="display:inline-block"
+                     ng-hide="!paginatingProgress"
+                     role="status">
+                    <span class="sr-only">Loading...</span>
+                </div>
+                <p class=" mb-1" ng-show="paginatingComplete"
+                   th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check"
+                                                                              aria-hidden="true"></i></p>
+                <p class=" mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"><i
+                        class="fa fa-check" aria-hidden="true"></i></p>
+            </div>
+            <div class="col-md-4 pt-2">
+                <input placeholder="Filter Members..." type="text" title="Filter Members"
+                       ng-model="membersQuery" class="form-control"
+                       ng-change="filter(groupingMembers, 'pagedItemsMembers', 'currentPageMembers', membersQuery, true)"/>
                 <!-- Export to CSV button -->
-                <button class="btn btn-sm btn-primary mb-4" type="submit" ng-click="exportGroupToCsv(groupingMembers, selectedGrouping.name, 'members')">
+                <button class="btn btn-sm btn-primary float-right mb-1 mt-1" type="submit"
+                        ng-click="exportGroupToCsv(groupingMembers, selectedGrouping.name, 'members')">
                     <i class="fa fa-refresh mr-2" aria-hidden="true"></i>
                     Export to CSV
                 </button>
             </div>
-            <div class="col-md-4">
-                <p class="pt-4 mb-1" ng-show="paginatingProgress" th:text="#{screen.message.common.loading.gettingmembers}"><i class="fa fa-spinner" aria-hidden="true"></i></p>
-                <p class="pt-4 mb-1" ng-show="paginatingComplete" th:text="#{screen.message.common.loading.loadcomplete}"><i class="fa fa-check" aria-hidden="true"></i></p>
-                <p class="pt-4 mb-1" ng-show="largeGrouping" th:text="#{screen.message.common.loading.toolarge}"> <i class="fa fa-check" aria-hidden="true"></i></p>
-                <input placeholder="Filter Members..." type="text" title="Filter Members"
-                       ng-model="membersQuery" class="form-control"
-                       ng-change="filter(groupingMembers, 'pagedItemsMembers', 'currentPageMembers', membersQuery, true)"/>
-            </div>
         </div>
 
 
-        <div class="table-responsive">
+        <div class="table-responsive-sm">
             <table class="table table-striped table-hover" aria-live="assertive">
                 <thead>
                 <tr>
@@ -45,17 +55,17 @@
                     </th>
                     <th scope="col" class="basis-column clickable"
                         ng-click="sortBy('groupingMembers', 'pagedItemsMembers', 'whereListed')">
-                        Where Listed?
+                        Listing?
                         <i class="fa sort-icon" ng-show="columnSort.groupingMembers.property === 'whereListed'"
                            ng-class="{ reverse: columnSort.groupingMembers.reverse }"></i>
                     </th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr ng-repeat="g in pagedItemsMembers[currentPageMembers]">
-                    <td>{{g.name}}</td>
-                    <td>{{g.uuid}}</td>
-                    <td>
+                <tr ng-repeat="g in pagedItemsMembers[currentPageMembers]" class="table table-sm">
+                    <td class="p-10">{{g.name}}</td>
+                    <td class="p-10">{{g.uuid}}</td>
+                    <td class="p-10">
                         {{g.username}}
                         <div ng-if="g.username === ''">
                             <span>N/A</span>
@@ -66,7 +76,7 @@
                             </i>
                         </div>
                     </td>
-                    <td class="basis-column text-center">{{ g.whereListed }}</td>
+                    <td class="basis-column text-center p-10">{{ g.whereListed }}</td>
                 </tr>
                 </tbody>
             </table>

--- a/src/main/resources/templates/fragments/owners.html
+++ b/src/main/resources/templates/fragments/owners.html
@@ -29,8 +29,8 @@
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="owner in pagedItemsOwners[currentPageOwners]">
-                <td tabindex="0">
+            <tr ng-repeat="owner in pagedItemsOwners[currentPageOwners]" class="table table-sm">
+                <td class="p-10" tabindex="0">
                     {{owner.name}}
                     <span class="fa fa-trash-o pull-right clickable pt-1"
                           data-toggle="tooltip" data-placement="top"
@@ -41,7 +41,7 @@
                           ng-click="removeOwner(currentPageOwners, $index)">
                     </span>
                 </td>
-                <td>
+                <td class="p-10">
                     {{owner.username}}
                     <div ng-if="owner.username === ''">
                         <span>N/A</span>

--- a/src/main/resources/templates/fragments/side-nav.html
+++ b/src/main/resources/templates/fragments/side-nav.html
@@ -1,5 +1,4 @@
 <th:block th:fragment="side-nav">
-<div class="col-lg-1 col-md-2 col-12 teal-tint-bg pt-3 pb-3" id="pills-column">
     <ul class="nav nav-pills flex-md-column flex-row justify-content-md-start justify-content-center"
         id="group-pills">
         <li class="nav-item mx-auto" data-toggle="tooltip" data-placement="right"
@@ -45,5 +44,4 @@
             </a>
         </li>
     </ul>
-</div>
 </th:block>


### PR DESCRIPTION
Realigned all table elements in the tables for basis/include/exclude/owners. Took out useless comments and unneeded code found in CSS file. Centered side navbar. Symmetrically realigned "all members/getting members" to filter bar and "export to CSV" button.