### PR TITLE
remove mail button on /info page

### DIFF
--- a/src/main/resources/templates/info.html
+++ b/src/main/resources/templates/info.html
@@ -74,7 +74,6 @@
                 <p class="pb-3">A grouping's Exclude overrides automatic and manual membership by explicitly not
                     including
                     anyone listed here. It may be empty.</p>
-                <a class="btn btn-primary dark-teal-bg" href="mailto:its-iam-help@lists.hawaii.edu">Send Email</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Removed send email button on the info page as it was random and unnecessary 