### PR TITLE
GROUPINGS-483 adjusted column size of the selected grouping name and the return to groupings button. 

### DIFF
--- a/src/main/resources/templates/fragments/selected-grouping.html
+++ b/src/main/resources/templates/fragments/selected-grouping.html
@@ -6,11 +6,11 @@
             <section>
                 <div class="card-header teal-bg">
                     <div class="row">
-                        <div class="col-md-9">
+                        <div class="col-md-6">
                             <h2 class="card-title text-light mb-0" style="display:inline-block"> {{
                                 selectedGrouping.name }}</h2>
                         </div>
-                        <div class="col-md-3">
+                        <div class="col-md-6">
                             <div class="float-right">
                                 <button class="btn btn-primary btn-sm" type="submit"
                                         ng-click="returnToGroupingsList(); cancelDescriptionEdit()">Return to Groupings


### PR DESCRIPTION
Columns are both size 6 and should fix the whitespace issue when the screen size shrinks. 