### PR TITLE
GROUPINGS-467 Return to groupings returns user to the groupings page that they were on. 

### DIFF
--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -1468,6 +1468,8 @@
             $scope.modelDescription = "";
             groupingDescription = "";
             displayTracker = 1;
+
+            $scope.setPage("Set", "currentPageGroupings", "pagedItemsGroupings"); // Function call to setPage that sets the current page which the user was on before a group was selected.
         };
 
         /**

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -1402,7 +1402,6 @@
             $scope.excludeQuery = "";
             $scope.includeQuery = "";
             $scope.membersQuery = "";
-            //$scope.groupingsQuery = "";
             $scope.adminsQuery = "";
             $scope.optInQuery = "";
             $scope.ownersQuery = "";
@@ -1458,9 +1457,6 @@
          */
         $scope.returnToGroupingsList = function () {
             $scope.resetGroupingInformation();
-
-            // Ensure the groupings list is reset with the now-blank filter
-            //$scope.filter($scope.groupingsList, "pagedItemsGroupings", "currentPageGroupings", $scope.groupingsQuery, true);
 
             $scope.showGrouping = false;
             loadMembersList = false;

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -1481,8 +1481,6 @@
             $scope.columnSort = {};
             $scope.syncDestArray = [];
 
-            // Displays the first page of the filter value when user presses "Return to Groupings".
-            $scope.setPage("First", "currentPageGroupings", "pagedItemsGroupings");
         };
 
 

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -1468,8 +1468,6 @@
             $scope.modelDescription = "";
             groupingDescription = "";
             displayTracker = 1;
-
-            $scope.setPage("Set", "currentPageGroupings", "pagedItemsGroupings"); // Function call to setPage that sets the current page which the user was on before a group was selected.
         };
 
         /**

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -1402,7 +1402,7 @@
             $scope.excludeQuery = "";
             $scope.includeQuery = "";
             $scope.membersQuery = "";
-            $scope.groupingsQuery = "";
+            //$scope.groupingsQuery = "";
             $scope.adminsQuery = "";
             $scope.optInQuery = "";
             $scope.ownersQuery = "";
@@ -1460,7 +1460,7 @@
             $scope.resetGroupingInformation();
 
             // Ensure the groupings list is reset with the now-blank filter
-            $scope.filter($scope.groupingsList, "pagedItemsGroupings", "currentPageGroupings", $scope.groupingsQuery, true);
+            //$scope.filter($scope.groupingsList, "pagedItemsGroupings", "currentPageGroupings", $scope.groupingsQuery, true);
 
             $scope.showGrouping = false;
             loadMembersList = false;
@@ -1482,7 +1482,11 @@
             clearAddMemberInput();
             $scope.columnSort = {};
             $scope.syncDestArray = [];
+
+            // Displays the first page of the filter value when user presses "Return to Groupings".
+            $scope.setPage("First", "currentPageGroupings", "pagedItemsGroupings");
         };
+
 
         /**
          * Creates a modal with a description of the preference selected.

--- a/src/main/resources/static/javascript/mainApp/table.controller.js
+++ b/src/main/resources/static/javascript/mainApp/table.controller.js
@@ -7,6 +7,7 @@
      */
     function TableJsController($scope, $filter) {
 
+        var currentPage; // Variable used to hold the current page that user was on before selecting a grouping.
         $scope.columnSort = {};
 
         $scope.itemsPerPage = 20;
@@ -107,29 +108,40 @@
          * @param {string} pagedListVar - the name of the variable contaning the paginated list
          */
         $scope.setPage = function (action, pageVar, pagedListVar) {
-            switch (action) {
-                case "First":
-                    $scope[pageVar] = 0;
-                    break;
-                case "Prev":
-                    if ($scope[pageVar] > 0) {
-                        $scope[pageVar]--;
-                    }
-                    break;
-                case "Set":
-                    if (this.n >= 0 && this.n <= $scope[pagedListVar].length - 1) {
-                        $scope[pageVar] = this.n;
-                    }
-                    break;
-                case "Next":
-                    if ($scope[pageVar] < $scope[pagedListVar].length - 1) {
-                        $scope[pageVar] = $scope[pageVar] + 1;
-                    }
-                    break;
-                case "Last":
-                    $scope[pageVar] = $scope[pagedListVar].length - 1;
-                    break;
-            }
+                switch (action) {
+                    case "First":
+                        $scope[pageVar] = 0;
+                        currentPage = $scope[pageVar];
+                        break;
+                    case "Prev":
+                        if ($scope[pageVar] > 0) {
+                            $scope[pageVar]--;
+                            currentPage = $scope[pageVar];
+                        }
+                        break;
+                    case "Set":
+                        if(currentPage == undefined) { // When the current page is the first page and the user didn't click on any of the items on the pagination.
+                            $scope[pageVar] = 0;
+                            currentPage = $scope[pageVar];
+                        }
+                        if (this.n >= 0 && this.n <= $scope[pagedListVar].length - 1) {
+                            $scope[pageVar] = this.n;
+                            currentPage = $scope[pageVar];
+                        }
+                        $scope[pageVar] = currentPage;
+                        break;
+                    case "Next":
+                        if ($scope[pageVar] < $scope[pagedListVar].length - 1) {
+                            $scope[pageVar] = $scope[pageVar] + 1;
+                            currentPage = $scope[pageVar];
+                        }
+                        break;
+                    case "Last":
+                        $scope[pageVar] = $scope[pagedListVar].length - 1;
+                        currentPage = $scope[pageVar];
+                        break;
+                }
+
         };
 
         /**

--- a/src/main/resources/static/javascript/mainApp/table.controller.js
+++ b/src/main/resources/static/javascript/mainApp/table.controller.js
@@ -7,7 +7,6 @@
      */
     function TableJsController($scope, $filter) {
 
-        var currentPage; // Variable used to hold the current page that user was on before selecting a grouping.
         $scope.columnSort = {};
 
         $scope.itemsPerPage = 20;
@@ -108,40 +107,29 @@
          * @param {string} pagedListVar - the name of the variable contaning the paginated list
          */
         $scope.setPage = function (action, pageVar, pagedListVar) {
-                switch (action) {
-                    case "First":
-                        $scope[pageVar] = 0;
-                        currentPage = $scope[pageVar];
-                        break;
-                    case "Prev":
-                        if ($scope[pageVar] > 0) {
-                            $scope[pageVar]--;
-                            currentPage = $scope[pageVar];
-                        }
-                        break;
-                    case "Set":
-                        if(currentPage == undefined) { // When the current page is the first page and the user didn't click on any of the items on the pagination.
-                            $scope[pageVar] = 0;
-                            currentPage = $scope[pageVar];
-                        }
-                        if (this.n >= 0 && this.n <= $scope[pagedListVar].length - 1) {
-                            $scope[pageVar] = this.n;
-                            currentPage = $scope[pageVar];
-                        }
-                        $scope[pageVar] = currentPage;
-                        break;
-                    case "Next":
-                        if ($scope[pageVar] < $scope[pagedListVar].length - 1) {
-                            $scope[pageVar] = $scope[pageVar] + 1;
-                            currentPage = $scope[pageVar];
-                        }
-                        break;
-                    case "Last":
-                        $scope[pageVar] = $scope[pagedListVar].length - 1;
-                        currentPage = $scope[pageVar];
-                        break;
-                }
-
+            switch (action) {
+                case "First":
+                    $scope[pageVar] = 0;
+                    break;
+                case "Prev":
+                    if ($scope[pageVar] > 0) {
+                        $scope[pageVar]--;
+                    }
+                    break;
+                case "Set":
+                    if (this.n >= 0 && this.n <= $scope[pagedListVar].length - 1) {
+                        $scope[pageVar] = this.n;
+                    }
+                    break;
+                case "Next":
+                    if ($scope[pageVar] < $scope[pagedListVar].length - 1) {
+                        $scope[pageVar] = $scope[pageVar] + 1;
+                    }
+                    break;
+                case "Last":
+                    $scope[pageVar] = $scope[pagedListVar].length - 1;
+                    break;
+            }
         };
 
         /**

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -39,7 +39,7 @@
                             <h2 class="card-title mt-md-1 mt-0 mb-1">Manage Groupings</h2>
                         </div>
                         <div class="col-lg-3 col-md-4 col-12 p-0">
-                            <input class="form-control" placeholder="Filter Groupings..." type="text"
+                            <input class="form-control" placeholder="Filter Groupings..." type="search"
                                    title="Filter Groupings"
                                    ng-model="groupingsQuery"
                                    ng-change="filter(groupingsList, 'pagedItemsGroupings', 'currentPageGroupings', groupingsQuery, true)"/>

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -55,7 +55,7 @@
                             <h2 class="card-title mt-md-1 mt-0 mb-1">Designate Admins</h2>
                         </div>
                         <div class="col-lg-3 col-md-4 col-12 p-0">
-                            <input class="form-control" placeholder="Filter Admins..." type="text"
+                            <input class="form-control" placeholder="Filter Admins..." type="search"
                                    title="Filter Admins"
                                    ng-model="adminsQuery"
                                    ng-change="filter(adminsList, 'pagedItemsAdmins', 'currentPageAdmins', adminsQuery, true)"/>

--- a/src/main/resources/templates/fragments/include.html
+++ b/src/main/resources/templates/fragments/include.html
@@ -97,7 +97,7 @@
             <div class="col-lg-4 pl-0 pr-0 mt-lg-0 mt-2">
                 <form ng-submit="addMembers('Include')">
                     <div class="input-group" style="width: 500px">
-                        <input class="form-control" placeholder="Members to add" type="text"
+                        <input class="form-control" placeholder="Members to add" type="search"
                                title="Enter one or more usernames" ng-model="usersToAdd" style="width: 275px"/>
                         <div>
                             <button class="btn btn-primary" type="submit" style="margin-left: 2px">Add</button>

--- a/src/main/resources/templates/groupings.html
+++ b/src/main/resources/templates/groupings.html
@@ -27,7 +27,7 @@
                                 Groupings</h2>
                         </div>
                         <div class="col-lg-3 col-md-4 col-12 p-0">
-                            <input class="form-control" placeholder="Filter Groupings..." type="text"
+                            <input class="form-control" placeholder="Filter Groupings..." type="search"
                                    title="Filter Groupings"
                                    ng-model="groupingsQuery"
                                    ng-change="filter(groupingsList, 'pagedItemsGroupings', 'currentPageGroupings', groupingsQuery, true)"/>

--- a/src/main/resources/templates/memberships.html
+++ b/src/main/resources/templates/memberships.html
@@ -39,7 +39,7 @@
                            th:utext="#{screen.message.memberships.page.currentMembershipsInfo}"></p>
                     </div>
                     <div class="col-lg-3 col-md-4 col-12 p-0 pt-3">
-                        <input placeholder="Filter Groupings..." type="text"
+                        <input placeholder="Filter Groupings..." type="search"
                                title="Filter Groupings"
                                ng-model="membersQuery" class="form-control"
                                ng-change="filter(membershipsList, 'pagedItemsMemberships', 'currentPageMemberships', membersQuery, true)"/>
@@ -116,7 +116,7 @@
                         <p th:utext="#{screen.message.memberships.page.membershipOpportunitiesInfo}"></p>
                     </div>
                     <div class="col-lg-3 col-md-4 col-12 p-0 pt-3">
-                        <input placeholder="Filter Groupings..." type="text"
+                        <input placeholder="Filter Groupings..." type="search"
                                title="Filter Groupings"
                                ng-model="optInQuery" class="form-control"
                                ng-change="filter(optInList, 'pagedItemsOptInList', 'currentPageOptIn', optInQuery, true)"


### PR DESCRIPTION
When the admin selects a grouping from the groupings list and presses Return to groupings, it should redirect them to the groupings list page that they were on. 
- Removed filter function that resets the filter which redirects back to the first when they select a grouping.
- When admin also uses filtering and selects a group, when "Return to groupings" is pressed, it should redirect them back to the search results of that filter input instead of the first page of the groupings list.
- All filter input boxes are also now given the type "search" instead of "text", which corresponds to what they are intended to do. 