### PR TITLE
Resolve Snyk errors by updating outdated dependencies in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
         <junit.version>4.12</junit.version>
         <org.jasig.cas.client-version>3.6.1</org.jasig.cas.client-version>
 
-        <jquery-version>3.2.0</jquery-version>
+        <jquery-version>3.4.1</jquery-version>
         <angular-mocks-version>1.7.5</angular-mocks-version>
         <angular-ui-bootstrap-version>2.2.0</angular-ui-bootstrap-version>
 
         <angularjs-version>1.7.8</angularjs-version>
         <bootstrap-version>4.3.1</bootstrap-version>
 
-        <lodash-version>4.17.4</lodash-version>
+        <lodash-version>4.17.15</lodash-version>
         <kotlin.version>1.3.61</kotlin.version>
         <spring.version>5.2.3.RELEASE</spring.version>
     </properties>
@@ -140,7 +140,7 @@
             <version>${angularjs-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.webjars</groupId>
+            <groupId>org.webjars.npm</groupId>
             <artifactId>lodash</artifactId>
             <version>${lodash-version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <org.jasig.cas.client-version>3.6.1</org.jasig.cas.client-version>
 
         <jquery-version>3.2.0</jquery-version>
-        <angular-mocks-version>1.5.8</angular-mocks-version>
+        <angular-mocks-version>1.7.5</angular-mocks-version>
         <angular-ui-bootstrap-version>2.2.0</angular-ui-bootstrap-version>
 
         <angularjs-version>1.7.8</angularjs-version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.2.4.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -30,7 +30,8 @@
         <bootstrap-version>4.3.1</bootstrap-version>
 
         <lodash-version>4.17.4</lodash-version>
-        <kotlin.version>1.2.71</kotlin.version>
+        <kotlin.version>1.3.61</kotlin.version>
+        <spring.version>5.2.3.RELEASE</spring.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven-war-plugin.version>2.4</maven-war-plugin.version>
         <java.version>1.8</java.version>
         <junit.version>4.12</junit.version>
-        <org.jasig.cas.client-version>3.4.1</org.jasig.cas.client-version>
+        <org.jasig.cas.client-version>3.6.1</org.jasig.cas.client-version>
 
         <jquery-version>3.2.0</jquery-version>
         <angular-mocks-version>1.5.8</angular-mocks-version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <org.jasig.cas.client-version>3.6.1</org.jasig.cas.client-version>
 
         <jquery-version>3.4.1</jquery-version>
-        <angular-mocks-version>1.7.5</angular-mocks-version>
+        <angular-mocks-version>1.7.9</angular-mocks-version>
         <angular-ui-bootstrap-version>2.2.0</angular-ui-bootstrap-version>
 
         <angularjs-version>1.7.8</angularjs-version>
@@ -161,7 +161,7 @@
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.webjars.bower</groupId>
+            <groupId>org.webjars.npm</groupId>
             <artifactId>angular-mocks</artifactId>
             <version>${angular-mocks-version}</version>
         </dependency>
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>webjars-locator-core</artifactId>
-            <version>0.37</version>
+            <version>0.43</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -191,6 +191,21 @@
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.1.2.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.64</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
30 Snyk errors have been resolved for the UI side by updating each vulnerable dependency to the recommended version.

The only issue remaining on Snyk has "No upgrade or patch available". The listed dependency on the issue is updated to the current version.