### PR TITLE
Remove maven wrapper instructions in README.md and revert dependency update commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ UH Groupings utilizes the Internet2 Grouper project.  Grouper is an enterprise a
 [![Build Status](https://travis-ci.org/uhawaii-system-its-ti-iam/uh-groupings-ui.png?branch=master)](https://travis-ci.org/uhawaii-system-its-ti-iam/uh-groupings-ui)
 [![Coverage Status](https://coveralls.io/repos/github/uhawaii-system-its-ti-iam/uh-groupings-ui/badge.svg?branch=master)](https://coveralls.io/github/uhawaii-system-its-ti-iam/uh-groupings-ui?branch=master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/69274196397f4587b88b0ecce5856d0a)](https://www.codacy.com/app/mhodgesatuh/uhgroupings?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=uhawaii-system-its-ti-iam/uhgroupings&amp;utm_campaign=Badge_Grade)
-##### Build Tool
-First, you need to setup [Maven Wrapper](https://www.baeldung.com/maven-wrapper) which allows the use of Maven withought installing it.
-
-    $ mvn -N io.takari:maven:wrapper
 
 ##### Java
 You'll need a Java JDK to build and run the project (version 1.8).
@@ -26,11 +22,11 @@ https://github.com/uhawaii-system-its-ti-iam/uh-groupings-ui
 ##### Building
 To run the Application from the Command Line:
 
-    $ ./mvnw clean spring-boot:run
+    $ mvn clean spring-boot:run
 
 To build a deployable war file for local development, if preferred:
 
-    $ ./mvnw clean package
+    $ mvn clean package
 
 You should have a deployable war file in the target directory.
 Deploy as usual in a servlet container, e.g. tomcat.
@@ -47,15 +43,15 @@ line arguments.
 
 To run the Unit Tests with a standard build:
 
-    $ ./mvnw clean test
+    $ mvn clean test
 
 To run a test class:
 
-    $ ./mvnw clean test -Dtest=StringsTest
+    $ mvn clean test -Dtest=StringsTest
 
 To run a single method in a test class:
 
-    $ ./mvnw clean test -Dtest=StringsTest#trunctate
+    $ mvn clean test -Dtest=StringsTest#trunctate
 
 ##### Running System Tests
 The project files include a handful of System Tests.
@@ -67,4 +63,4 @@ appropriate command line argument.
 
 To run the System Tests:
 
-    $ ./mvnw -Dtest=*SystemTest clean test
+    $ mvn -Dtest=*SystemTest clean test


### PR DESCRIPTION
Jenkins error appeared on the test side after updating dependencies and committing to master. Changes to the pom file were reverted to resolve the jenkins error.

Maven wrapper instructions were included in the list of commits that failed Jenkins test, reverted pom file changes but kept commit that changed the readme.