### PR TITLE
Update spring framework and kotlin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <bootstrap-version>4.3.1</bootstrap-version>
 
         <lodash-version>4.17.4</lodash-version>
-        <kotlin.version>1.2.71</kotlin.version>
+        <kotlin.version>1.3.61</kotlin.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.2.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
org.springframework.boot:spring-boot-starter-parent has been updated to 2.2.3.RELEASE to match the API side.

kotlin.version has been updated to 1.3.61.

This reduces the current number of Snyk vulnerabilities from 32 to 17.