### PR TITLE
Update groupId for angular-mocks and update version to 1.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <org.jasig.cas.client-version>3.6.1</org.jasig.cas.client-version>
 
         <jquery-version>3.2.0</jquery-version>
-        <angular-mocks-version>1.5.8</angular-mocks-version>
+        <angular-mocks-version>1.7.9</angular-mocks-version>
         <angular-ui-bootstrap-version>2.5.0</angular-ui-bootstrap-version>
 
         <angularjs-version>1.7.8</angularjs-version>
@@ -187,7 +187,7 @@
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.webjars.bower</groupId>
+            <groupId>org.webjars.npm</groupId>
             <artifactId>angular-mocks</artifactId>
             <version>${angular-mocks-version}</version>
         </dependency>


### PR DESCRIPTION
Webjars' website states that the groupId org.webjars.bower is depreciated. Because of this, switched groupId to org.webjars.npm instead, and updated angular-mocks version to 1.7.9.