### PR TITLE
Fix Confirmation modal overflow text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M1</version>
                 <configuration>
-                    <!--forkMode>never</forkMode-->
+                    <forkMode>never</forkMode>
                     <excludes>
                         <exclude>**/Test*.java</exclude>
                     </excludes>

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -312,6 +312,12 @@ table .p-12 {
     opacity: .5;
 }
 
+
+.modal-names {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .modal-dialog {
     display: -ms-flexbox;
     display: flex;

--- a/src/main/resources/templates/modal/multiAddResultModal.html
+++ b/src/main/resources/templates/modal/multiAddResultModal.html
@@ -22,7 +22,7 @@
             <tbody class="import-table-tbody">
             <tr class="import-table-thead-tbody-tr" ng-repeat="person in multiAddResults">
                 <!-- Display table data -->
-                <td ng-repeat="prop in personProps">
+                <td class="modal-names" ng-repeat="prop in personProps">
                     {{ person[prop] }}
                 </td>
             </tr>


### PR DESCRIPTION
Fix issue where member's first name would overflow if their name was too long and also fixed pom file that resulted in a failed build. 