### PR TITLE
Changed the icon for grouping

### DIFF
--- a/src/main/resources/templates/fragments/groupings-list.html
+++ b/src/main/resources/templates/fragments/groupings-list.html
@@ -22,9 +22,8 @@
                 <td class="p-10 clickable align-middle" tabindex="0"
                     ng-keypress="$event.keyCode === 13 ? displayGrouping(currentPageGroupings, $index) : null"
                     ng-click="displayGrouping(currentPageGroupings, $index)">
-                    <i class="fa fa-fw fa-pencil-square-o" aria-hidden="true"></i>
-
-                  {{l.name}}
+                    <i class="fa fa-id-card-o" style="color: #004e59;" aria-hidden="true"></i>
+                    {{l.name}}
                 </td>
 
                 <td class="p-10 d-none d-md-table-cell">


### PR DESCRIPTION
The orignal icon that was at grouping may lead to user think it for edit. Now, it change to a better one with a matching coloring of the logo.