### PR TITLE
fix deprecated forkmode in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M1</version>
                 <configuration>
-                    <forkMode>never</forkMode>
+                    <forkCount>0</forkCount>
                     <excludes>
                         <exclude>**/Test*.java</exclude>
                     </excludes>


### PR DESCRIPTION
forkMode was deprecated in an upgraded version of maven, so forkCount should now be used 