### PR TITLE
fix console error warnings

### DIFF
--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -141,7 +141,7 @@
          */
         groupingsService.getNumberOfMemberships((res) => {
                 $scope.numberOfMemberships = res;
-            }
+            }, (res) => { }
         );
 
         /**

--- a/src/main/resources/static/javascript/mainApp/membership.controller.js
+++ b/src/main/resources/static/javascript/mainApp/membership.controller.js
@@ -35,7 +35,7 @@
                     // Codacy throws an error regarding the '_' in the uniqBy function. This error will be ignored until a solution is found.
                   $scope.membershipsList = _.filter(_.sortBy(_.uniqBy(res, "name"), "name"), (membership) => {return membership.inInclude || membership.inOwner;});
                   $scope.pagedItemsMemberships = $scope.objToPageArray($scope.membershipsList, 20);
-                    $scope.loading = false;
+                  $scope.loading = false;
                 },
                 (res) => {
                     $scope.createApiErrorModal();

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -7,7 +7,7 @@
 
 
 </head>
-<body ng-app="UHGroupingsApp" onload="loaded();">
+<body ng-app="UHGroupingsApp">
 <nav th:replace="menubar :: copy"></nav>
 <!--  Content container -->
 


### PR DESCRIPTION
[GROUPINGS-986](https://www.hawaii.edu/jira/browse/GROUPINGS-986)
loaded() is a old function that has been removed, and is no longer needed, removing `onload="loaded()"` fixes the warning

getNumberOfMemberships() uses loadData() to retrieve the membership number, but it takes a while to return the number from the API, so when we refresh the page before the number is returned, we get an error. I gave getNumberOfMemberships() a empty onError function to remove the console warning, might not be best fix.