### PR TITLE
fix console error warnings for dev-2-2-0

### DIFF
--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -139,7 +139,7 @@
          */
         groupingsService.getNumberOfMemberships((res) => {
                 $scope.numberOfMemberships = res;
-            }
+            }, (res) => { }
         );
 
         /**


### PR DESCRIPTION
[GROUPINGS-986](https://www.hawaii.edu/jira/browse/GROUPINGS-986)

getNumberOfMemberships() uses loadData() to retrieve the membership number, but it takes a while to return the number from the API, so when we refresh the page before the number is returned, we get an error. I gave getNumberOfMemberships() a empty onError function to remove the console warning, might not be best fix.