### PR TITLE
Fix loading members indicator not going away after members have been …

### DIFF
--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -339,6 +339,7 @@
                     $scope.syncDestArray = res.syncDestinations;
                     $scope.loading = false;
                     $scope.paginatingProgress = false;
+                    $scope.paginatingComplete = true;
 
                     //increments page to load and allows members to iteratively be loaded
                     currentPage++;
@@ -380,8 +381,9 @@
             } else {
                 return loadMembersList = false;
             }
+            $scope.paginatingComplete = false;
         };
-
+        
         /**
          * Function to get pages of a grouping asynchronously
          * @param {String} groupingPath - Path to the grouping to retrieve data from


### PR DESCRIPTION
…loaded

# Ticket Link

[GROUPINGS-1063](https://www.hawaii.edu/jira/browse/GROUPINGS-1063)

# List of squashed commits

- Fix loading members indicator not going away after members have been loaded

# Test Checklist

- [x ] Unit Tests Passed:
- [x ] Jasmine Tests Passed:
- [x ] General Visual Inspection:

