### PR TITLE
[UI Side] Changes add/remove member request to contain a body

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
@@ -1,7 +1,9 @@
 package edu.hawaii.its.api.controller;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -89,7 +91,7 @@ public class GroupingsRestController {
 
     // Constructor.
     public GroupingsRestController() {
-        policy = Sanitizers.FORMATTING.and(Sanitizers.LINKS);
+        policy = Sanitizers.FORMATTING;
     }
 
     /*
@@ -274,63 +276,59 @@ public class GroupingsRestController {
     /**
      * Add a list of usersToAdd to include group of grouping at path.
      */
-    @PostMapping(value = "/{groupingPath}/{usersToAdd}/addMembersToIncludeGroup")
+    @PutMapping(value = "/{groupingPath}/addMembersToIncludeGroup")
     public ResponseEntity<String> addMembersToIncludeGroup(Principal principal,
             @PathVariable String groupingPath,
-            @PathVariable String usersToAdd) {
+            @RequestBody List<String> usersToAdd) {
         logger.info("Entered REST addMembersToIncludeGroup...");
         String safeGroupingPath = policy.sanitize(groupingPath);
-        String safeUsersToAdd = policy.sanitize(usersToAdd);
-        String uri = String.format(API_2_1_BASE + "/groupings/%s/include-members/%s", safeGroupingPath,
-                safeUsersToAdd);
-        return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.PUT);
+        List<String> safeUsersToAdd = sanitizeList(usersToAdd);
+        String uri = String.format(API_2_1_BASE + "/groupings/%s/include-members", safeGroupingPath);
+        return httpRequestService.makeApiRequestWithBody(principal.getName(), uri, safeUsersToAdd, HttpMethod.PUT);
     }
 
     /**
      * Add a list of usersToAdd to exclude group of grouping at path.
      */
-    @PostMapping(value = "/{groupingPath}/{usersToAdd}/addMembersToExcludeGroup")
+    @PutMapping(value = "/{groupingPath}/addMembersToExcludeGroup")
     public ResponseEntity<String> addMembersToExcludeGroup(Principal principal,
             @PathVariable String groupingPath,
-            @PathVariable String usersToAdd) {
+            @RequestBody List<String> usersToAdd) {
         logger.info("Entered REST addMembersToExcludeGroup...");
         String safeGroupingPath = policy.sanitize(groupingPath);
-        String safeUsersToAdd = policy.sanitize(usersToAdd);
-        String uri = String.format(API_2_1_BASE + "/groupings/%s/exclude-members/%s", safeGroupingPath,
-                safeUsersToAdd);
-        return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.PUT);
+        List<String> safeUsersToAdd = sanitizeList(usersToAdd);
+        String uri = String.format(API_2_1_BASE + "/groupings/%s/exclude-members", safeGroupingPath);
+        return httpRequestService.makeApiRequestWithBody(principal.getName(), uri, safeUsersToAdd, HttpMethod.PUT);
     }
 
     /**
      * Remove a list of users from include group of grouping at path.
      */
-    @PostMapping(value = "/{groupingPath}/{usersToDelete}/removeMembersFromIncludeGroup")
+    @PutMapping(value = "/{groupingPath}/removeMembersFromIncludeGroup")
     public ResponseEntity<String> removeMembersFromIncludeGroup(Principal principal,
             @PathVariable String groupingPath,
-            @PathVariable String usersToDelete) {
+            @RequestBody List<String> usersToDelete) {
         logger.info("Entered REST deleteMembersFromIncludeGroup...");
         String safeGroupingPath = policy.sanitize(groupingPath);
-        String safeUserToDelete = policy.sanitize(usersToDelete);
+        List<String> safeUsersToDelete = sanitizeList(usersToDelete);
         String uri =
-                String.format(API_2_1_BASE + "/groupings/%s/include-members/%s", safeGroupingPath,
-                        safeUserToDelete);
-        return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.DELETE);
+                String.format(API_2_1_BASE + "/groupings/%s/include-members", safeGroupingPath);
+        return httpRequestService.makeApiRequestWithBody(principal.getName(), uri, safeUsersToDelete, HttpMethod.DELETE);
     }
 
     /**
      * Remove a list of users from exclude group of grouping at path.
      */
-    @PostMapping(value = "/{groupingPath}/{usersToDelete}/removeMembersFromExcludeGroup")
+    @PutMapping(value = "/{groupingPath}/removeMembersFromExcludeGroup")
     public ResponseEntity<String> removeMembersFromExcludeGroup(Principal principal,
             @PathVariable String groupingPath,
-            @PathVariable String usersToDelete) {
+            @RequestBody List<String> usersToDelete) {
         logger.info("Entered REST deleteMembersFromExcludeGroup...");
         String safeGroupingPath = policy.sanitize(groupingPath);
-        String safeUserToDelete = policy.sanitize(usersToDelete);
+        List<String> safeUsersToDelete = sanitizeList(usersToDelete);
         String uri =
-                String.format(API_2_1_BASE + "/groupings/%s/exclude-members/%s", safeGroupingPath,
-                        safeUserToDelete);
-        return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.DELETE);
+                String.format(API_2_1_BASE + "/groupings/%s/exclude-members", safeGroupingPath);
+        return httpRequestService.makeApiRequestWithBody(principal.getName(), uri, safeUsersToDelete, HttpMethod.DELETE);
     }
 
     /**
@@ -512,6 +510,21 @@ public class GroupingsRestController {
     ///////////////////////////////////////////////////////////////////////
     // Helper Methods
     //////////////////////////////////////////////////////////////////////
+
+    public List<String> sanitizeList(List<String> data) {
+        List<String> sanitizedList = new ArrayList<>();
+        String sanitizedString;
+
+        for (int i = 0; i < data.size(); i++) {
+            sanitizedString = policy.sanitize(data.get(i));
+
+            if (!(sanitizedString.isEmpty())) {
+                sanitizedList.add(sanitizedString);
+            }
+        }
+
+        return sanitizedList;
+    }
 
     public Map<String, String> mapGroupingParameters(Integer page, Integer size, String sortString,
             Boolean isAscending) {

--- a/src/main/java/edu/hawaii/its/api/service/HttpRequestService.java
+++ b/src/main/java/edu/hawaii/its/api/service/HttpRequestService.java
@@ -3,6 +3,7 @@ package edu.hawaii.its.api.service;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
 import java.util.Map;
 
 public interface HttpRequestService {
@@ -10,6 +11,8 @@ public interface HttpRequestService {
     ResponseEntity<String> makeApiRequest(String currentUser, String uri, HttpMethod method);
 
     ResponseEntity<String> makeApiRequestWithBody(String currentUser, String uri, String data, HttpMethod method);
+
+    ResponseEntity<String> makeApiRequestWithBody(String currentUser, String uri, List<String> data, HttpMethod method);
 
     ResponseEntity<String> makeApiRequestWithParameters(String currentUser, String urlTemplate, Map<String, String> params, HttpMethod method);
 

--- a/src/main/java/edu/hawaii/its/api/service/HttpRequestServiceImpl.java
+++ b/src/main/java/edu/hawaii/its/api/service/HttpRequestServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 @Service("httpRequestService")
@@ -46,6 +47,19 @@ public class HttpRequestServiceImpl implements HttpRequestService {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.set(CURRENT_USER, currentUser);
         HttpEntity<String> httpEntity = new HttpEntity<>(data, httpHeaders);
+
+        RestTemplate restTemplate =
+                new RestTemplateBuilder().errorHandler(new RestTemplateResponseErrorHandler()).build();
+        return restTemplate.exchange(uri, method, httpEntity, String.class);
+    }
+
+    @Override
+    public ResponseEntity<String> makeApiRequestWithBody(String currentUser, String uri, List<String> data,
+                                                         HttpMethod method) {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set(CURRENT_USER, currentUser);
+        HttpEntity<List<String>> httpEntity = new HttpEntity<>(data, httpHeaders);
 
         RestTemplate restTemplate =
                 new RestTemplateBuilder().errorHandler(new RestTemplateResponseErrorHandler()).build();

--- a/src/main/java/edu/hawaii/its/groupings/util/JsonUtil.java
+++ b/src/main/java/edu/hawaii/its/groupings/util/JsonUtil.java
@@ -1,0 +1,56 @@
+package edu.hawaii.its.groupings.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class JsonUtil {
+    private static final Log logger = LogFactory.getLog(JsonUtil.class);
+
+    // Private constructor to prevent instantiation.
+    private JsonUtil() {
+        // Empty.
+    }
+
+    public static String asJson(final Object obj) {
+        String result = null;
+        try {
+            result = new ObjectMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            logger.error("Error: " + e);
+            // Maybe we should throw something?
+        }
+        return result;
+    }
+
+    public static <T> T asObject(final String json, Class<T> type) {
+        T result = null;
+        try {
+            result = new ObjectMapper().readValue(json, type);
+        } catch (Exception e) {
+            logger.error("Error: " + e);
+            // Maybe we should throw something?
+        }
+        return result;
+    }
+
+    public static void printJson(Object obj) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String json = objectMapper.writeValueAsString(obj);
+            System.err.println(json);
+        } catch (Exception e) {
+            logger.error("Error: " + e);
+        }
+    }
+    public static void prettyPrint(Object object) {
+        try {
+            String json = new ObjectMapper()
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(object);
+            System.out.println(json);
+        } catch (Exception e) {
+            logger.error("Error: " + e);
+        }
+    }
+}

--- a/src/main/resources/static/javascript/mainApp/app.service.js
+++ b/src/main/resources/static/javascript/mainApp/app.service.js
@@ -98,6 +98,27 @@
             },
 
             /**
+             * PUT data to the server, if the response is OK then call the callBack function, if the response is an
+             * error then call the callError function. If the response is not received in n seconds, launch a modal.
+             * @param {string} url - Path to which data is being posted too.
+             * @param {string} data - data to be updated
+             * @param {function} modal - Launch a modal using a call back function.
+             * @param {function} callback - Execute if response returns OK
+             * @param {function} callError - Execute if response returns as an error.
+             */
+            updateDataWithBodyAndTimeoutModal(url, data, callback, callError, modal) {
+                let timeoutID = setTimeout(modal, timeLimit);
+                $http.put(encodeURI(url), data)
+                    .then(function (response) {
+                        clearTimeout(timeoutID);
+                        callback(response.data);
+                    }, function (response) {
+                        clearTimeout(timeoutID);
+                        callError(response);
+                    });
+            },
+
+            /**
              * Handle Java exceptions by performing a POST request.
              * @param {object} exceptionData - an object containing the exception (stored as a string)
              * @param {string} url - the endpoint to perform the POST request

--- a/src/main/resources/static/javascript/mainApp/groupings.service.js
+++ b/src/main/resources/static/javascript/mainApp/groupings.service.js
@@ -70,8 +70,8 @@
              * of time has elapsed.
              */
             addMembersToInclude(usersToAdd, path, onSuccess, onError) {
-                let endpoint = BASE_URL + path + "/" + usersToAdd + "/addMembersToIncludeGroup";
-                dataProvider.updateData(endpoint, onSuccess, onError);
+                let endpoint = BASE_URL + path + "/addMembersToIncludeGroup";
+                dataProvider.updateDataWithBody(endpoint, usersToAdd, onSuccess, onError);
             },
 
             /**
@@ -79,9 +79,9 @@
              * of time has elapsed.
              */
             addMembersToIncludeAsync(usersToAdd, path, onSuccess, onError, modal) {
-                let endpoint = BASE_URL + path + "/" + usersToAdd + "/addMembersToIncludeGroup";
+                let endpoint = BASE_URL + path + "/addMembersToIncludeGroup";
                 return new Promise((resolve) => {
-                    dataProvider.updateDataWithTimeoutModal(endpoint, onSuccess, onError, modal);
+                    dataProvider.updateDataWithBodyAndTimeoutModal(endpoint, usersToAdd, onSuccess, onError, modal);
                 });
             },
 
@@ -90,17 +90,17 @@
              * of time has elapsed.
              */
             addMembersToExclude(usersToAdd, path, onSuccess, onError) {
-                let endpoint = BASE_URL + path + "/" + usersToAdd + "/addMembersToExcludeGroup";
-                dataProvider.updateData(endpoint, onSuccess, onError);
+                let endpoint = BASE_URL + path + "/addMembersToExcludeGroup";
+                dataProvider.updateDataWithBody(endpoint, usersToAdd, onSuccess, onError);
             },
             /**
              * Add a members to the exclude group of a grouping. A modal is passed in an launched after a certain amount
              * of time has elapsed.
              */
             addMembersToExcludeAsync(usersToAdd, path, onSuccess, onError, modal) {
-                let endpoint = BASE_URL + path + "/" + usersToAdd + "/addMembersToExcludeGroup";
+                let endpoint = BASE_URL + path + "/addMembersToExcludeGroup";
                 return new Promise((resolve) => {
-                    dataProvider.updateDataWithTimeoutModal(endpoint, onSuccess, onError, modal);
+                    dataProvider.updateDataWithBodyAndTimeoutModal(endpoint, usersToAdd, onSuccess, onError, modal);
                 });
             },
 
@@ -132,16 +132,16 @@
              * Remove members from include group of grouping.
              */
             removeMembersFromInclude(path, members, onSuccess, onError) {
-                let endpoint = BASE_URL + path + "/" + members + "/removeMembersFromIncludeGroup";
-                dataProvider.updateData(endpoint, onSuccess, onError);
+                let endpoint = BASE_URL + path + "/removeMembersFromIncludeGroup";
+                dataProvider.updateDataWithBody(endpoint, members, onSuccess, onError);
             },
 
             /**
              * Remove members from exclude group of grouping.
              */
             removeMembersFromExclude(path, members, onSuccess, onError) {
-                let endpoint = BASE_URL + path + "/" + members + "/removeMembersFromExcludeGroup";
-                dataProvider.updateData(endpoint, onSuccess, onError);
+                let endpoint = BASE_URL + path + "/removeMembersFromExcludeGroup";
+                dataProvider.updateDataWithBody(endpoint, members, onSuccess, onError);
             },
 
             /**

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
@@ -1,8 +1,11 @@
 package edu.hawaii.its.api.controller;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import edu.hawaii.its.groupings.util.JsonUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -34,9 +38,11 @@ import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
@@ -59,7 +65,6 @@ public class GroupingsRestControllerTest {
 
     private static final String GROUPING = "grouping1";
     private static final String GROUPING2 = "grouping2";
-    private static final String GROUPING3 = "grouping3";
     private static final String USERNAME = "user";
     private static final String REST_CONTROLLER_BASE = "/api/groupings/";
     private static final String ADMIN_USERNAME = "admin";
@@ -185,7 +190,7 @@ public class GroupingsRestControllerTest {
     @Test
     @WithMockUhUser(username = "admin")
     public void removeFromGroupsTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + GROUPING3 + "/user/removeFromGroups";
+        String uri = REST_CONTROLLER_BASE + GROUPING2 + "/user/removeFromGroups";
 
         given(httpRequestService.makeApiRequest(eq(ADMIN_USERNAME), anyString(), eq(HttpMethod.DELETE)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
@@ -330,66 +335,82 @@ public class GroupingsRestControllerTest {
     @Test
     @WithMockUhUser
     public void addMembersToIncludeGroupTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + GROUPING + "/" + USERNAME + "/addMembersToIncludeGroup";
+        String uri = REST_CONTROLLER_BASE + GROUPING + "/addMembersToIncludeGroup";
+        List<String> usersToAdd = new ArrayList<>();
+        usersToAdd.add(USERNAME);
 
-        given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.PUT)))
+        given(httpRequestService.makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.PUT)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
 
-        assertNotNull(mockMvc.perform(post(uri).with(csrf()))
+        assertNotNull(mockMvc.perform(put(uri).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToAdd)))
                 .andExpect(status().isOk())
                 .andReturn());
 
         verify(httpRequestService, times(1))
-                .makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.PUT));
+                .makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.PUT));
 
     }
 
     @Test
     @WithMockUhUser
     public void addMembersToExcludeGroupTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + GROUPING + "/" + USERNAME + "/addMembersToExcludeGroup";
+        String uri = REST_CONTROLLER_BASE + GROUPING + "/addMembersToExcludeGroup";
+        List<String> usersToAdd = new ArrayList<>();
+        usersToAdd.add(USERNAME);
 
-        given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.PUT)))
+        given(httpRequestService.makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.PUT)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
 
-        assertNotNull(mockMvc.perform(post(uri).with(csrf()))
+        assertNotNull(mockMvc.perform(put(uri).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToAdd)))
                 .andExpect(status().isOk())
                 .andReturn());
 
         verify(httpRequestService, times(1))
-                .makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.PUT));
+                .makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.PUT));
     }
 
     @Test
     @WithMockUhUser
     public void removeMembersFromIncludeGroupTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + GROUPING + "/" + USERNAME + "/removeMembersFromIncludeGroup";
+        String uri = REST_CONTROLLER_BASE + GROUPING + "/removeMembersFromIncludeGroup";
+        List<String> usersToRemove = new ArrayList<>();
+        usersToRemove.add(USERNAME);
 
-        given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.DELETE)))
+        given(httpRequestService.makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.DELETE)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
 
-        assertNotNull(mockMvc.perform(post(uri).with(csrf()))
+        assertNotNull(mockMvc.perform(put(uri).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToRemove)))
                 .andExpect(status().isOk())
                 .andReturn());
 
         verify(httpRequestService, times(1))
-                .makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.DELETE));
+                .makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.DELETE));
     }
 
     @Test
     @WithMockUhUser
     public void removeMembersFromExcludeGroupTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + GROUPING + "/" + USERNAME + "/removeMembersFromExcludeGroup";
+        String uri = REST_CONTROLLER_BASE + GROUPING + "/removeMembersFromExcludeGroup";
+        List<String> usersToRemove = new ArrayList<>();
+        usersToRemove.add(USERNAME);
 
-        given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.DELETE)))
+        given(httpRequestService.makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.DELETE)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
 
-        assertNotNull(mockMvc.perform(post(uri).with(csrf()))
+        assertNotNull(mockMvc.perform(put(uri).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToRemove)))
                 .andExpect(status().isOk())
                 .andReturn());
 
         verify(httpRequestService, times(1))
-                .makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.DELETE));
+                .makeApiRequestWithBody(eq(USERNAME), anyString(), anyList(), eq(HttpMethod.DELETE));
     }
 
     @Test
@@ -510,7 +531,7 @@ public class GroupingsRestControllerTest {
     public void updateDescriptionTest() throws Exception {
         String uri = REST_CONTROLLER_BASE + "groupings/path/description";
 
-        given(httpRequestService.makeApiRequestWithBody(eq(USERNAME), anyString(), eq(null), eq(HttpMethod.PUT)))
+        given(httpRequestService.makeApiRequestWithBody(eq(USERNAME), anyString(), nullable(String.class), eq(HttpMethod.PUT)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
 
         assertNotNull(mockMvc.perform(put(uri).with(csrf()))
@@ -518,7 +539,7 @@ public class GroupingsRestControllerTest {
                 .andReturn());
 
         verify(httpRequestService, times(1))
-                .makeApiRequestWithBody(eq(USERNAME), anyString(), eq(null), eq(HttpMethod.PUT));
+                .makeApiRequestWithBody(eq(USERNAME), anyString(), nullable(String.class), eq(HttpMethod.PUT));
     }
 
     @Test
@@ -755,4 +776,20 @@ public class GroupingsRestControllerTest {
         assertEquals(expectedResult, uriTemplate);
     }
 
+    @Test
+    public void sanitizeListTest() {
+        List<String> listToSanitize = new ArrayList<>();
+        listToSanitize.add(USERNAME);
+        listToSanitize.add("<a href='/foo?param1=1&param2=2'></a>");
+        listToSanitize.add("<p style='color: red'></p>");
+        listToSanitize.add("<img></img>");
+        listToSanitize.add("<script></script>");
+
+        List<String> sanitizedList = groupingsRestController.sanitizeList(listToSanitize);
+        assertTrue(sanitizedList.contains(USERNAME));
+        assertFalse(sanitizedList.contains("<a href='/foo?param1=1&param2=2'></a>"));
+        assertFalse(sanitizedList.contains("<p style='color: red'></p>"));
+        assertFalse(sanitizedList.contains("<img></img>"));
+        assertFalse(sanitizedList.contains("<script></script>"));
+    }
 }

--- a/src/test/java/edu/hawaii/its/groupings/util/JsonUtilTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/util/JsonUtilTest.java
@@ -1,0 +1,45 @@
+package edu.hawaii.its.groupings.util;
+
+import org.junit.jupiter.api.Test;
+import edu.hawaii.its.groupings.type.Feedback;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JsonUtilTest {
+
+    @Test
+    public void basics() {
+        Feedback fb0 = new Feedback("message");
+        String fbJson = JsonUtil.asJson(fb0);
+
+        Feedback fb1 = JsonUtil.asObject(fbJson, Feedback.class);
+
+        assertEquals(fb0.getName(), fb1.getName());
+        assertEquals(fb0.getEmail(), fb1.getEmail());
+        assertEquals(fb0.getType(), fb1.getType());
+        assertEquals(fb0.getMessage(), fb1.getMessage());
+        assertEquals(fb0.getExceptionMessage(), fb1.getExceptionMessage());
+    }
+
+    @Test
+    public void problems() {
+        String json = JsonUtil.asJson(null);
+        assertEquals(json, "null");
+
+        json = JsonUtil.asJson("{}");
+        assertEquals(json, "\"{}\"");
+
+        json = JsonUtil.asJson("mistake");
+        assertEquals(json, "\"mistake\"");
+    }
+
+    @Test
+    public void constructorIsPrivate() throws Exception {
+        Constructor<JsonUtil> constructor = JsonUtil.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+    }
+}

--- a/src/test/javascript/general.controller.test.js
+++ b/src/test/javascript/general.controller.test.js
@@ -1552,18 +1552,20 @@ describe("GeneralController", () => {
         let commaSeparated = "Hello,I,love,you";
         let commaAndSpaceSeparated = "Hello, I love,you";
         let single = "Hello";
+        let arrayCreated = ["Hello", "I", "love", "you"];
+        let singleArrayCreated = ["Hello"];
 
-        it("should take a space separated string and replace the spaces with ','", () => {
-            expect(scope.parseAddRemoveInputStr(spaceSeparated)).toEqual(commaSeparated);
+        it("should take a space separated string and create an array", () => {
+            expect(scope.parseAddRemoveInputStr(spaceSeparated)).toEqual(arrayCreated);
         });
-        it("should take a comma separated string and do nothing", () => {
-            expect(scope.parseAddRemoveInputStr(commaSeparated)).toEqual(commaSeparated);
+        it("should take a comma separated string and create an array", () => {
+            expect(scope.parseAddRemoveInputStr(commaSeparated)).toEqual(arrayCreated);
         });
-        it("should take a comma and space separated string and replace the spaces amd commas with ','", () => {
-            expect(scope.parseAddRemoveInputStr(commaAndSpaceSeparated)).toEqual(commaSeparated);
+        it("should take a comma and space separated string and create an array", () => {
+            expect(scope.parseAddRemoveInputStr(commaAndSpaceSeparated)).toEqual(arrayCreated);
         });
-        it("should do nothing with a string that has no commas or spaces", () => {
-            expect(scope.parseAddRemoveInputStr(single)).toEqual(single);
+        it("should take a string that has no commas or spaces and create an array", () => {
+            expect(scope.parseAddRemoveInputStr(single)).toEqual(singleArrayCreated);
         });
         it("should return an empty string if value passed is not a string", () => {
             expect(scope.parseAddRemoveInputStr(true)).toEqual("");

--- a/src/test/javascript/groupings.service.test.js
+++ b/src/test/javascript/groupings.service.test.js
@@ -98,15 +98,15 @@ describe("GroupingsService", function () {
     describe("addMembersToInclude", function () {
         let usersToAdd;
 
-        it("should call dataProvider.updateData", function () {
-            spyOn(dp, "updateData");
+        it("should call dataProvider.updateDataWithBody", function () {
+            spyOn(dp, "updateDataWithBody");
             gs.addMembersToInclude(usersToAdd, groupingPath, onSuccess, onError);
-            expect(dp.updateData).toHaveBeenCalled();
+            expect(dp.updateDataWithBody).toHaveBeenCalled();
         });
 
         it("should use the correct path", function () {
             gs.addMembersToInclude(usersToAdd, groupingPath, onSuccess, onError);
-            httpBackend.expectPOST(BASE_URL + groupingPath + "/" + usersToAdd + "/addMembersToIncludeGroup").respond(200);
+            httpBackend.expectPUT(BASE_URL + groupingPath + "/addMembersToIncludeGroup").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });
@@ -114,29 +114,29 @@ describe("GroupingsService", function () {
     describe("addMembersToIncludeAsync", function () {
         let usersToAdd;
         let modal;
-        it("should call dataProvider.updateDataWithTimeoutModal", function () {
-            spyOn(dp, "updateDataWithTimeoutModal");
+        it("should call dataProvider.updateDataWithBodyAndTimeoutModal", function () {
+            spyOn(dp, "updateDataWithBodyAndTimeoutModal");
             gs.addMembersToIncludeAsync(usersToAdd, groupingPath, onSuccess, onError, modal);
-            expect(dp.updateDataWithTimeoutModal).toHaveBeenCalled();
+            expect(dp.updateDataWithBodyAndTimeoutModal).toHaveBeenCalled();
         });
 
         it("should use the correct path", function () {
             gs.addMembersToInclude(usersToAdd, groupingPath, onSuccess, onError);
-            httpBackend.expectPOST(BASE_URL + groupingPath + "/" + usersToAdd + "/addMembersToIncludeGroup").respond(200);
+            httpBackend.expectPUT(BASE_URL + groupingPath + "/addMembersToIncludeGroup").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });
 
     describe("addMembersToExclude", function () {
         let usersToAdd;
-        it("should call dataProvider.updateData", function () {
-            spyOn(dp, "updateData");
+        it("should call dataProvider.updateDataWithBody", function () {
+            spyOn(dp, "updateDataWithBody");
             gs.addMembersToExclude(usersToAdd, groupingPath, onSuccess, onError);
-            expect(dp.updateData).toHaveBeenCalled();
+            expect(dp.updateDataWithBody).toHaveBeenCalled();
         });
         it("should use the correct path", function () {
             gs.addMembersToExclude(usersToAdd, groupingPath, onSuccess, onError);
-            httpBackend.expectPOST(BASE_URL + groupingPath + "/" + usersToAdd + "/addMembersToExcludeGroup").respond(200);
+            httpBackend.expectPUT(BASE_URL + groupingPath + "/addMembersToExcludeGroup").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });
@@ -144,14 +144,14 @@ describe("GroupingsService", function () {
     describe("addMembersToExcludeAsync", function () {
         let usersToAdd;
         let modal;
-        it("should call dataProvider.updateDataWithTimeoutModal", function () {
-            spyOn(dp, "updateDataWithTimeoutModal");
+        it("should call dataProvider.updateDataWithBodyAndTimeoutModal", function () {
+            spyOn(dp, "updateDataWithBodyAndTimeoutModal");
             gs.addMembersToExcludeAsync(usersToAdd, groupingPath, onSuccess, onError, modal);
-            expect(dp.updateDataWithTimeoutModal).toHaveBeenCalled();
+            expect(dp.updateDataWithBodyAndTimeoutModal).toHaveBeenCalled();
         });
         it("should use the correct path", function () {
             gs.addMembersToExclude(usersToAdd, groupingPath, onSuccess, onError);
-            httpBackend.expectPOST(BASE_URL + groupingPath + "/" + usersToAdd + "/addMembersToExcludeGroup").respond(200);
+            httpBackend.expectPUT(BASE_URL + groupingPath + "/addMembersToExcludeGroup").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });
@@ -201,28 +201,28 @@ describe("GroupingsService", function () {
 
     describe("removeMembersFromInclude", function () {
         let members;
-        it("should call dataProvider.updateData", function () {
-            spyOn(dp, "updateData");
+        it("should call dataProvider.updateDataWithBody", function () {
+            spyOn(dp, "updateDataWithBody");
             gs.removeMembersFromInclude(groupingPath, members, onSuccess, onError);
-            expect(dp.updateData).toHaveBeenCalled();
+            expect(dp.updateDataWithBody).toHaveBeenCalled();
         });
         it("should use the correct path", function () {
             gs.removeMembersFromInclude(groupingPath, members, onSuccess, onError);
-            httpBackend.expectPOST(BASE_URL + groupingPath + "/" + members + "/removeMembersFromIncludeGroup").respond(200);
+            httpBackend.expectPUT(BASE_URL + groupingPath + "/removeMembersFromIncludeGroup").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });
 
     describe("removeMembersFromExclude", function () {
         let members;
-        it("should call dataProvider.updateData", function () {
-            spyOn(dp, "updateData");
+        it("should call dataProvider.updateDataWithBody", function () {
+            spyOn(dp, "updateDataWithBody");
             gs.removeMembersFromExclude(groupingPath, members, onSuccess, onError);
-            expect(dp.updateData).toHaveBeenCalled();
+            expect(dp.updateDataWithBody).toHaveBeenCalled();
         });
         it("should use the correct path", function () {
             gs.removeMembersFromExclude(groupingPath, members, onSuccess, onError);
-            httpBackend.expectPOST(BASE_URL + groupingPath + "/" + members + "/removeMembersFromExcludeGroup").respond(200);
+            httpBackend.expectPUT(BASE_URL + groupingPath + "/removeMembersFromExcludeGroup").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });


### PR DESCRIPTION
# Ticket Link

[Groupings-1214](https://uhawaii.atlassian.net/browse/GROUPINGS-1214)

# List of squashed commits

- Changed all add and remove member functions in general.controller.js to make a PUT request with an ArrayList instead of a comma-separated string of members
- Added makeApiRequestWithBody and makeApiRequestWithBodyAndTimeoutModal to groupings.service.js
- Changed GroupingsRestController to expect a PUT request with a body instead of a header
- Added sanitizeList helper method with 100% Jacoco test coverage to GroupingsRestController to sanitize a list of strings
- Added another makeApiRequestBody in HttpRequestService that takes a list of data instead of string in the parameter
- Added JsonUtil and JsonUtilTest from the API side to use in unit tests (Convert list into json when performing mockMvc.content())
- Updated Unit and Jasmine tests

# Test Checklist

- [x] Unit Tests Passed:
- [x] Jasmine Tests Passed:
- [x] General Visual Inspection:

