### PR TITLE
Refactors remove member functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.webjars.bower</groupId>
+            <artifactId>jasmine</artifactId>
+            <version>3.7.1</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>

--- a/src/main/java/edu/hawaii/its/groupings/controller/HomeController.java
+++ b/src/main/java/edu/hawaii/its/groupings/controller/HomeController.java
@@ -216,13 +216,13 @@ public class HomeController {
         return "modal/multiAddResultModal";
     }
 
-    @GetMapping(value = "/modal/multiRemovePromptModal")
-    public String multiRemovePromptModal() {
-        return "modal/multiRemovePromptModal";
+    @GetMapping(value = "/modal/multiRemoveModal")
+    public String multiRemoveModal() {
+        return "modal/multiRemoveModal";
     }
 
-    @GetMapping(value = "/modal/multiRemoveConfirmationModal")
+    @GetMapping(value = "/modal/multiRemoveResultModal")
     public String multiRemoveConfirmationModal() {
-        return "modal/multiRemoveConfirmationModal";
+        return "modal/multiRemoveResultModal";
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -45,8 +45,8 @@ screen.message.modal.multiremove.multiowner=If you remove yourself, you will no 
 screen.message.modal.remove.admin=If you remove yourself, you will no longer have access to the admin page.
 
 screen.message.modal.remove.confirmation=You are about to remove the following member from the
-screen.message.modal.remove.memberInfo=Name: {{ userToRemove.name }}<br/>UH Username: {{ userToRemove.username }}<br/>UH Number: {{ userToRemove.uhUuid }}
-screen.message.modal.remove.finalConfirm=Are you sure you want to remove {{ userToRemove.username }} from the {{ listName }} list?
+screen.message.modal.remove.memberInfo=Name: {{ memberToRemove.name }}<br/>UH Username: {{ memberToRemove.username }}<br/>UH Number: {{ memberToRemove.uhUuid }}
+screen.message.modal.remove.finalConfirm=Are you sure you want to remove {{ memberToRemove.username }} from the {{ listName }} list?
 
 screen.message.modal.remove.name=Name:
 screen.message.modal.remove.uid=UH Username:
@@ -63,7 +63,7 @@ screen.message.modal.access.relog=Please re-login to access your new permissions
 screen.message.modal.access.opt.error=Groupings encountered a problem with your opt request.
 screen.message.modal.access.opt.feedback=If the error persists please refer to our feedback page.
 ## Modal batch remove
-# Title: multiRemovePromptModal.html
+# Title: multiRemoveModal.html
 screen.message.modal.multiremove.message=You are about to remove the following members from the
 ## Modal Add
 #Title: Confirm Adding New Member

--- a/src/main/resources/static/javascript/mainApp/admin.controller.js
+++ b/src/main/resources/static/javascript/mainApp/admin.controller.js
@@ -18,6 +18,7 @@
         $scope.personList = [];
         $scope.pagedItemsPerson = [];
         $scope.currentPagePerson = 0;
+        $scope.personToLookup = "";
         $scope.currentManagePerson = "";
         $scope.selectedGroupingsPaths = [];
         $scope.emptySelect = false;
@@ -63,7 +64,7 @@
          */
         $scope.searchForUserGroupingInformation = function () {
             $scope.loading = true;
-            const validUser = $scope.sanitizer([$scope.personToLookup]);
+            const validUser = $scope.sanitizer($scope.personToLookup);
             if (validUser !== "") {
                 groupingsService.getMembershipAssignmentForUser(
                     $scope.searchForUserGroupingInformationOnSuccessCallback,
@@ -99,7 +100,7 @@
             if (res === "") {
                 return;
             }
-            let userToRemove = {
+            let memberToRemove = {
                 username: res.username,
                 name: res.name,
                 uhUuid: res.uhUuid
@@ -108,29 +109,29 @@
             $scope.soleOwnerGroupingNames = [];
 
             if ($scope.selectedOwnedGroupings.length === 0) {
-                $scope.removeFromGroupsCallbackOnSuccess(userToRemove);
+                $scope.removeFromGroupsCallbackOnSuccess(memberToRemove);
             }
             _.forEach($scope.selectedOwnedGroupings, function (grouping) {
-                    groupingsService.isSoleOwner(grouping.path, userToRemove.username, (res) => {
+                    groupingsService.isSoleOwner(grouping.path, memberToRemove.username, (res) => {
                         if (res) {
                             $scope.soleOwnerGroupingNames.push(grouping.name);
                         }
                         if (grouping === $scope.selectedOwnedGroupings[$scope.selectedOwnedGroupings.length - 1]) {
-                            $scope.removeFromGroupsCallbackOnSuccess(userToRemove);
+                            $scope.removeFromGroupsCallbackOnSuccess(memberToRemove);
                         }
                     }, () => $scope.createApiErrorModal());
                 }
             );
         };
 
-        $scope.removeFromGroupsCallbackOnSuccess = function (userToRemove) {
+        $scope.removeFromGroupsCallbackOnSuccess = function (memberToRemove) {
             if (_.isEmpty($scope.selectedGroupingsPaths)) {
                 $scope.emptySelect = true;
             } else if ($scope.soleOwnerGroupingNames.length >= 1) {
                 $scope.createRemoveErrorModal("owner");
             } else {
                 $scope.createRemoveFromGroupsModal({
-                    user: userToRemove,
+                    member: memberToRemove,
                     groupPaths: $scope.selectedGroupingsPaths,
                     listName: $scope.selectedGroupingsNames
                 });
@@ -205,7 +206,7 @@
          */
         $scope.addAdmin = function () {
             $scope.waitingForImportResponse = true;
-            const sanitizedAdmin = $scope.sanitizer([$scope.adminToAdd]);
+            const sanitizedAdmin = $scope.sanitizer($scope.adminToAdd);
             if (_.isEmpty(sanitizedAdmin)) {
                 // Todo : Error message pop up needs implementation.
                 $scope.emptyInput = true;
@@ -236,7 +237,7 @@
 
             if ($scope.adminsList.length > 1) {
                 $scope.createRemoveModal({
-                    user: adminToRemove,
+                    members: adminToRemove,
                     listName: "admins"
                 });
             } else {
@@ -258,14 +259,14 @@
          * Create a modal that prompts the user whether they want to delete the user or not. If 'Yes' is pressed, then
          * a request is made to delete the user.
          * @param {object} options - the options object
-         * @param {object} options.user - the user being removed
+         * @param {object} options.member - the user being removed
          * @param {string} options.groupPaths - groups the user is being removed from
          * @param {string} options.listName - groups the user is being removed from
          */
         $scope.createRemoveFromGroupsModal = function (options) {
-            const userToRemove = options.user.uhUuid;
-            const sanitizedUser = $scope.sanitizer([userToRemove]);
-            $scope.userToRemove = options.user;
+            const memberToRemove = options.member.uhUuid;
+            const sanitizedUser = $scope.sanitizer(memberToRemove);
+            $scope.memberToRemove = options.member;
             $scope.groupPaths = options.groupPaths;
             $scope.listName = options.listName;
             $scope.ownerOfListName = $scope.selectedOwnedGroupingsNames.join(", ");
@@ -288,12 +289,12 @@
 
                 $scope.removeModalInstance.result.then(function () {
                     $scope.loading = true;
-                    let userToRemove = options.user.uhUuid;
+                    let memberToRemove = options.member.uhUuid;
                     let groupingPath = $scope.groupPaths;
-                    groupingsService.removeFromGroups(groupingPath, userToRemove, handleRemoveFromGroupsOnSuccess, handleRemoveFromGroupsOnError);
+                    groupingsService.removeFromGroups(groupingPath, memberToRemove, handleRemoveFromGroupsOnSuccess, handleRemoveFromGroupsOnError);
                 });
             }, function (res) {
-                $scope.user = userToRemove;
+                $scope.user = memberToRemove;
                 $scope.resStatus = res.status;
             });
         };

--- a/src/main/resources/static/javascript/mainApp/groupings.service.js
+++ b/src/main/resources/static/javascript/mainApp/groupings.service.js
@@ -105,7 +105,7 @@
             },
 
             /**
-             * Add a member to the exclude group of a grouping.
+             * Add owners to owners group of grouping
              */
             addOwnerships(path, newOwner, onSuccess, onError) {
                 let endpoint = BASE_URL + path + "/" + newOwner + "/addOwnerships";
@@ -147,7 +147,7 @@
             /**
              * Remove owners from owners group of grouping
              */
-            removeOwners(path, owners, onSuccess, onError) {
+            removeOwnerships(path, owners, onSuccess, onError) {
                 let endpoint = BASE_URL + path + "/" + owners + "/removeOwnerships";
                 dataProvider.updateData(endpoint, onSuccess, onError);
             },

--- a/src/main/resources/templates/fragments/owners.html
+++ b/src/main/resources/templates/fragments/owners.html
@@ -41,8 +41,8 @@
                               onmouseover="$(this).tooltip('show')" onmouseout="$(this).tooltip('dispose')"
                               tabindex="0" aria-label="Remove {{owner.name}} from the Owner members list"
                               th:title="#{screen.message.common.tooltip.remove.owner}"
-                              ng-keypress="$event.keyCode === 13 ? removeOwner(currentPageOwners, $index) : null"
-                              ng-click="removeOwner(currentPageOwners, $index)">
+                              ng-keypress="$event.keyCode === 13 ? removeOwnerWithTrashcan(currentPageOwners, $index) : null"
+                              ng-click="removeOwnerWithTrashcan(currentPageOwners, $index)">
                     </span>
                     </td>
                     <td class="p-10">
@@ -69,7 +69,7 @@
                                ng-init="dismissErrors()"  aria-required="true"
                                ng-blur="dismissErrors()"
                                title="Enter one or more UH members"
-                               ng-model="manageOwners"
+                               ng-model="manageMembers"
                                aria-label="Enter one or more UH members to add to the Owners list"
                                id="owner-input"/>
                         </div>

--- a/src/main/resources/templates/modal/multiRemoveModal.html
+++ b/src/main/resources/templates/modal/multiRemoveModal.html
@@ -28,6 +28,17 @@
             </div>
         </div>
     </div>
+    <div class="modal-danger-message" ng-if="showWarningRemovingSelfFromList()">
+        <p th:utext="#{screen.message.modal.remove.warning}">Warning</p>
+        <div>
+            <div ng-if="selectedOwnedGroupingsNames.length === 1">
+                <p th:text="#{screen.message.modal.multiremove.owner}"></p>
+            </div>
+            <div ng-if="selectedOwnedGroupingsNames.length > 1">
+                <p th:text="#{screen.message.modal.multiremove.multiowner}"></p>
+            </div>
+        </div>
+    </div>
     <p>
         <span class="modal-black-text" th:text="#{screen.message.modal.multiremove.message}"></span>
         <span class="modal-black-text">{{ listName }} list.</span>
@@ -57,8 +68,8 @@
     <span class="modal-black-text">{{membersNotInList}}</span>
 </div>
 <div class="modal-footer">
-    <button class="btn btn-primary" ng-click="batchRemovePromptModalAccept()">Remove</button>
-    <button class="btn btn-default" ng-click="batchRemovePromptModalCancel()" data-dismiss="modal">Cancel</button>
+    <button class="btn btn-primary" ng-click="removeModalProceed()">Remove</button>
+    <button class="btn btn-light" ng-click="removeModalCancel()" data-dismiss="modal">Cancel</button>
 </div>
 
 </html>

--- a/src/main/resources/templates/modal/multiRemoveResultModal.html
+++ b/src/main/resources/templates/modal/multiRemoveResultModal.html
@@ -2,12 +2,12 @@
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4"
       lang="en">
 <div class="modal-header">
-    <h5 class="modal-title" id="modal-title">Multi-removal Confirmation</h5>
+    <h5 class="modal-title" id="modal-title">Multi-Removal Confirmation</h5>
 </div>
 <div class="modal-body" id="modal-body">
     <p>All selected members have been removed successfully.</p>
 </div>
 <div class="modal-footer">
-    <button class="btn btn-primary" ng-click="closeBatchRemoveConfirmationModalInstance()">OK</button>
+    <button class="btn btn-primary" ng-click="closeSuccessfulMultiRemoveModal()">OK</button>
 </div>
 </html>

--- a/src/main/resources/templates/modal/removeModal.html
+++ b/src/main/resources/templates/modal/removeModal.html
@@ -64,8 +64,8 @@
     </p>
 </div>
 <div class="modal-footer">
-    <button class="btn btn-primary" ng-click="proceedRemoveUser()">Yes</button>
-    <button class="btn btn-light" ng-click="cancelRemoveUser()" data-dismiss="modal">Cancel</button>
+    <button class="btn btn-primary" ng-click="removeModalProceed()">Yes</button>
+    <button class="btn btn-light" ng-click="removeModalCancel()" data-dismiss="modal">Cancel</button>
 </div>
 
 </html>

--- a/src/test/java/edu/hawaii/its/groupings/controller/HomeControllerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/controller/HomeControllerTest.java
@@ -493,20 +493,20 @@ public class HomeControllerTest {
 
     @Test
     @WithMockUhUser(username = "uh")
-    public void requestMultiRemovePromptModal() throws Exception {
-        MvcResult mvcResult = mockMvc.perform(get("/modal/multiRemovePromptModal"))
+    public void requestMultiRemoveModal() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/modal/multiRemoveModal"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("modal/multiRemovePromptModal"))
+                .andExpect(view().name("modal/multiRemoveModal"))
                 .andReturn();
         assertNotNull(mvcResult);
     }
 
     @Test
     @WithMockUhUser(username = "uh")
-    public void requestMultiRemoveConfirmationModal() throws Exception {
-        MvcResult mvcResult = mockMvc.perform(get("/modal/multiRemoveConfirmationModal"))
+    public void requestMultiRemoveResultModal() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/modal/multiRemoveResultModal"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("modal/multiRemoveConfirmationModal"))
+                .andExpect(view().name("modal/multiRemoveResultModal"))
                 .andReturn();
         assertNotNull(mvcResult);
     }

--- a/src/test/javascript/admin.controller.test.js
+++ b/src/test/javascript/admin.controller.test.js
@@ -341,23 +341,6 @@ describe("AdminController", function () {
         });
     });
 
-    describe("removeAdmin", function () {
-        beforeEach(function () {
-            scope.pagedItemsAdmins[0] = "zzzz";
-        });
-        it("should call scope.createRemoveModal", () => {
-            scope.adminsList = ["iamtst01", "iamtst02", "iamtst03"];
-            spyOn(scope, "createRemoveModal").and.callThrough();
-            scope.removeAdmin(0, 0);
-            expect(scope.createRemoveModal).toHaveBeenCalled();
-        });
-        it("should call scope.createRemoveErrorModal", function () {
-            spyOn(scope, "createRemoveErrorModal").and.callThrough();
-            scope.removeAdmin(0, 0);
-            expect(scope.createRemoveErrorModal).toHaveBeenCalled();
-        });
-    });
-
     describe("addAdmin", () => {
         it("should check that the admin to add is in the admin list", () => {
             scope.adminToAdd = "iamtst01";
@@ -381,11 +364,27 @@ describe("AdminController", function () {
 
     describe("removeAdmin", () => {
         beforeEach(() => {
-            scope.pagedItemsAdmins[0] = "zzzz";
+            scope.pagedItemsAdmins[0] = {name: "zzz", username: "zzz", uhUuid: "zzz"};
         });
         it("should call scope.createRemoveModal", () => {
-            scope.adminsList = ["iamtst01", "iamtst02", "iamtst03"];
-            spyOn(scope, "createRemoveModal");
+            scope.adminsList = [
+                {
+                    name: "iamtst01",
+                    username: "iamtst01",
+                    uhUuid: "iamtst01"
+                },
+                {
+                    name: "iamtst02",
+                    username: "iamtst02",
+                    uhUuid: "iamtst02"
+                },
+                {
+                    name: "iamtst03",
+                    username: "iamtst03",
+                    uhUuid: "iamtst03"
+                }
+            ];
+            spyOn(scope, "createRemoveModal").and.callThrough();
             scope.removeAdmin(0, 0);
             expect(scope.createRemoveModal).toHaveBeenCalled();
         });
@@ -397,15 +396,15 @@ describe("AdminController", function () {
     });
 
     describe("createRemoveFromGroupsModal", () => {
-        let options = { user: { uhUuid: "testId" }, groupPaths: "testPath", listName: "testList" };
+        let options = { member: { uhUuid: "testId" }, groupPaths: "testPath", listName: "testList" };
 
         it("should set scope variables to passed in option's object", () => {
-            scope.userToRemove = {};
+            scope.memberToRemove = {};
             scope.groupPaths = "badPath";
             scope.listName = "badList";
             scope.createRemoveFromGroupsModal(options);
 
-            expect(scope.userToRemove).toEqual({ uhUuid: "testId" });
+            expect(scope.memberToRemove).toEqual({ uhUuid: "testId" });
             expect(scope.groupPaths).toBe("testPath");
             expect(scope.listName).toBe("testList");
             expect(scope.ownerOfListName).toBe("");

--- a/src/test/javascript/groupings.service.test.js
+++ b/src/test/javascript/groupings.service.test.js
@@ -231,11 +231,11 @@ describe("GroupingsService", function () {
         let ownerToRemove;
         it("should call dataProvider.updateData", function () {
             spyOn(dp, "updateData");
-            gs.removeOwners(groupingPath, ownerToRemove, onSuccess, onError);
+            gs.removeOwnerships(groupingPath, ownerToRemove, onSuccess, onError);
             expect(dp.updateData).toHaveBeenCalled();
         });
         it("should use the correct path", function () {
-            gs.removeOwners(groupingPath, ownerToRemove, onSuccess, onError);
+            gs.removeOwnerships(groupingPath, ownerToRemove, onSuccess, onError);
             httpBackend.expectPOST(BASE_URL + groupingPath + "/" + ownerToRemove + "/removeOwnerships").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });


### PR DESCRIPTION
# Ticket Link

[Groupings-1243](https://uhawaii.atlassian.net/browse/GROUPINGS-1243)

# List of squashed commits

### Renamed variables and functions ###
- userToRemove -> memberToRemove and usersToRemove ->membersToRemove
- multiRemovePromptModal -> multiRemoveModal and multiRemoveConfirmationModal -> multiRemoveResultModal
- returnMemberObjectFromUserIdentifier -> returnMemberObject, changed it to take in listName instead of currentPage as parameter
- handleMemberRemove() to handleSuccessfulRemove() to match handleSuccessfulAdd()
- removeOwners() in general.controller.js to removeOwnersWithTrashcan()
- removeOwners() in groupings.service.js to removeOwnerships() to match addOwnerships()

### Additions/Removals ###
- Readded Jasmine testing to pom.xml
- Removed prepBatchRemove()
- Adding warning message when attempting to remove yourself (the owner of the grouping) in multi-remove modal
- Created functions $scope.createSuccessfulMultiRemoveModal() and $scope.closeSuccessfulMultiRemoveModal() that are called when the multi-removal is successful

### Modifications ###
- Changed $scope.sanitizer to take in either a string or array as the parameter then return a string or array depending on what was passed in; Removed its joiner functionality.
- Depreciated $scope.manageOwners and replaced it with $scope.manageMembers.
- Updated Jasmine tests, removed duplicate removeMember test in admin.controller.test.js

# Test Checklist

- [x] Unit Tests Passed:
- [x] Jasmine Tests Passed:
- [x] General Visual Inspection:

