### PR TITLE
Fixes the manage memberships table

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
@@ -200,7 +200,18 @@ public class GroupingsRestController {
     @GetMapping(value = "/members/groupings")
     public ResponseEntity<String> membershipResults(Principal principal) {
         logger.info("Entered REST membershipResults...");
-        String uri = String.format(API_2_1_BASE + "/members/%s/groupings", principal.getName());
+        String principalName = policy.sanitize(principal.getName());
+        String uri = String.format(API_2_1_BASE + "/members/%s/groupings", principalName);
+        return httpRequestService.makeApiRequest(principalName, uri, HttpMethod.GET);
+    }
+
+    /**
+     * Get a list of all groupings that the current user is associated with.
+     */
+    @GetMapping(value = "/members/groupings/all")
+    public ResponseEntity<String> managePersonResults(Principal principal) {
+        logger.info("Entered REST managePersonResults...");
+        String uri = String.format(API_2_1_BASE + "/members/%s/groupings/all", principal.getName());
         return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.GET);
     }
 

--- a/src/main/resources/static/javascript/mainApp/admin.controller.js
+++ b/src/main/resources/static/javascript/mainApp/admin.controller.js
@@ -87,7 +87,7 @@
          * @param validUser
          */
         $scope.getMemberDetails = function (validUser) {
-            groupingsService.getMembershipAssignmentForUser(
+            groupingsService.managePersonResults(
                 $scope.searchForUserGroupingInformationOnSuccessCallback,
                 $scope.searchForUserGroupingInformationOnErrorCallback,
                 $scope.personToLookup);

--- a/src/main/resources/static/javascript/mainApp/groupings.service.js
+++ b/src/main/resources/static/javascript/mainApp/groupings.service.js
@@ -191,6 +191,14 @@
                 dataProvider.loadData(endpoint, onSuccess, onError);
             },
 
+            /**
+             * Get a list of all groupings that a user is associated with.
+             */
+            managePersonResults(onSuccess, onError) {
+                let endpoint = BASE_URL + "members/groupings/all/";
+                dataProvider.loadData(endpoint, onSuccess, onError);
+            },
+
 
             /**
              * Get the number of memberships that the current user is associated with.

--- a/src/main/resources/static/javascript/mainApp/membership.controller.js
+++ b/src/main/resources/static/javascript/mainApp/membership.controller.js
@@ -35,9 +35,7 @@
             // Request a list of membership objects from the API.
             groupingsService.getMembershipResults((res) => {
                     // Codacy throws an error regarding the '_' in the uniqBy function. This error will be ignored until a solution is found.
-                    $scope.membershipsList = _.filter(_.sortBy(_.uniqBy(res, "name"), "name"), (membership) => {
-                        return membership.inInclude;
-                    });
+                    $scope.membershipsList = _.sortBy(_.uniqBy(res, "name"), "name");
                     $scope.pagedItemsMemberships = $scope.objToPageArray($scope.membershipsList, 20);
                     $scope.loading = false;
                 },

--- a/src/test/javascript/admin.controller.test.js
+++ b/src/test/javascript/admin.controller.test.js
@@ -176,11 +176,11 @@ describe("AdminController", function () {
             expect(scope.personList).toEqual([]);
             expect(scope.currentManagePerson).toEqual("");
         });
-        it("should call groupingsService.getMembershipAssignmentForUser", () => {
+        it("should call groupingsService.managePersonResults", () => {
             scope.personToLookup = "iamtst01";
-            spyOn(gs, "getMembershipAssignmentForUser").and.callThrough();
+            spyOn(gs, "managePersonResults").and.callThrough();
             scope.searchForUserGroupingInformation();
-            expect(gs.getMembershipAssignmentForUser).toHaveBeenCalled();
+            expect(gs.managePersonResults).toHaveBeenCalled();
         });
         it("should call groupingsService.getMemberAttributes", () => {
             scope.personToLookup = "iamtst01";

--- a/src/test/javascript/groupings.service.test.js
+++ b/src/test/javascript/groupings.service.test.js
@@ -310,6 +310,20 @@ describe("GroupingsService", function () {
         });
     });
 
+    describe("managePersonResults", function () {
+        it("should call dataProvider.loadData", function () {
+            spyOn(dp, "loadData");
+            gs.managePersonResults(onSuccess, onError);
+            expect(dp.loadData).toHaveBeenCalled();
+        });
+
+        it("should use the correct path", function () {
+            gs.managePersonResults(onSuccess, onError);
+            httpBackend.expectGET(BASE_URL + "members/groupings/all/").respond(200);
+            expect(httpBackend.flush).not.toThrow();
+        });
+    });
+
     describe("getNumberOfMemberships", function () {
         it("should call dataProvider.loadData", function () {
             spyOn(dp, "loadData");


### PR DESCRIPTION
# Ticket Link

[GROUPINGS-1278](https://uhawaii.atlassian.net/browse/GROUPINGS-1278)
done in conjunction with: https://github.com/uhawaii-system-its-ti-iam/uh-groupings-api/pull/388

# List of squashed commits

- Removes filter for membershipResults
- Adds managePersonResults from API
- Edits tests for getMembershipResults and makes test for managePersonResults
- Adds sanitizer to membershipResults 
- Changes safeInput to principalName

# Test Checklist

- [X] Unit Tests Passed:
- [X] Jasmine Tests Passed:
- [X] General Visual Inspection:

