### PR TITLE
Renames endpoints for membershipResults and managePersonResults

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
@@ -197,32 +197,32 @@ public class GroupingsRestController {
     /**
      * Get a list of memberships that the current user is associated with.
      */
-    @GetMapping(value = "/members/groupings")
+    @GetMapping(value = "/members/memberships")
     public ResponseEntity<String> membershipResults(Principal principal) {
         logger.info("Entered REST membershipResults...");
         String principalName = policy.sanitize(principal.getName());
-        String uri = String.format(API_2_1_BASE + "/members/%s/groupings", principalName);
+        String uri = String.format(API_2_1_BASE + "/members/%s/memberships", principalName);
         return httpRequestService.makeApiRequest(principalName, uri, HttpMethod.GET);
     }
 
     /**
      * Get a list of all groupings that the uhIdentifier is associated with.
      */
-    @GetMapping(value = "/members/{uhIdentifier}/groupings/all")
+    @GetMapping(value = "/members/{uhIdentifier}/groupings")
     public ResponseEntity<String> managePersonResults(Principal principal, @PathVariable String uhIdentifier) {
         logger.info("Entered REST managePersonResults...");
         String safeInput = policy.sanitize(uhIdentifier);
-        String uri = String.format(API_2_1_BASE + "/members/%s/groupings/all", safeInput);
+        String uri = String.format(API_2_1_BASE + "/members/%s/groupings", safeInput);
         return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.GET);
     }
 
     /**
      * Get the number of memberships that the current user is associated with.
      */
-    @GetMapping(value = "/members/memberships")
+    @GetMapping(value = "/members/memberships/count")
     public ResponseEntity<String> numberOfMemberships(Principal principal) {
         logger.info("Entered REST numberOfMemberships...");
-        String uri = String.format(API_2_1_BASE + "/groupings/members/%s/memberships", principal.getName());
+        String uri = String.format(API_2_1_BASE + "/members/%s/memberships/count", principal.getName());
         return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.GET);
     }
 
@@ -342,10 +342,10 @@ public class GroupingsRestController {
     /**
      * Request the number of grouping paths owned by principal.
      */
-    @GetMapping(value = "/owners/grouping")
+    @GetMapping(value = "/owners/groupings/count")
     public ResponseEntity<String> numberOfGroupings(Principal principal) {
         logger.info("Entered REST numberOfGroupings...");
-        String uri = String.format(API_2_1_BASE + "/owners/%s/grouping", principal.getName());
+        String uri = String.format(API_2_1_BASE + "/owners/%s/groupings/count", principal.getName());
         return httpRequestService.makeApiRequest(principal.getName(), uri, HttpMethod.GET);
     }
 

--- a/src/main/resources/static/javascript/mainApp/groupings.service.js
+++ b/src/main/resources/static/javascript/mainApp/groupings.service.js
@@ -187,7 +187,7 @@
              * Get a list of memberships that the current user is associated with.
              */
             getMembershipResults(onSuccess, onError) {
-                let endpoint = BASE_URL + "members/groupings/";
+                let endpoint = BASE_URL + "members/memberships/";
                 dataProvider.loadData(endpoint, onSuccess, onError);
             },
 
@@ -195,7 +195,7 @@
              * Get a list of all groupings that a user is associated with.
              */
             managePersonResults(uhIdentifier, onSuccess, onError) {
-                let endpoint = BASE_URL + "members/" + uhIdentifier + "/groupings/all";
+                let endpoint = BASE_URL + "members/" + uhIdentifier + "/groupings/";
                 dataProvider.loadData(endpoint, onSuccess, onError);
             },
 
@@ -204,7 +204,7 @@
              * Get the number of memberships that the current user is associated with.
              */
             getNumberOfMemberships(onSuccess, onError) {
-                let endpoint = BASE_URL + "members/memberships/";
+                let endpoint = BASE_URL + "members/memberships/count";
                 dataProvider.loadData(endpoint, onSuccess, onError);
             },
 
@@ -279,7 +279,7 @@
              * Get the number of groupings a member owns.
              */
             getNumberOfGroupings(onSuccess, onError) {
-                let endpoint = BASE_URL + "owners/grouping/";
+                let endpoint = BASE_URL + "owners/groupings/count";
                 dataProvider.loadData(endpoint, onSuccess, onError);
             },
 

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
@@ -1,35 +1,5 @@
 package edu.hawaii.its.api.controller;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import edu.hawaii.its.groupings.util.JsonUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationContext;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.context.WebApplicationContext;
-
-import edu.hawaii.its.api.service.HttpRequestService;
-import edu.hawaii.its.groupings.configuration.Realm;
-import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
-import edu.hawaii.its.groupings.controller.WithMockUhUser;
-import edu.hawaii.its.groupings.exceptions.ApiServerHandshakeException;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -57,6 +27,35 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import edu.hawaii.its.api.service.HttpRequestService;
+import edu.hawaii.its.groupings.configuration.Realm;
+import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
+import edu.hawaii.its.groupings.controller.WithMockUhUser;
+import edu.hawaii.its.groupings.exceptions.ApiServerHandshakeException;
+import edu.hawaii.its.groupings.util.JsonUtil;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles("localTest")
@@ -238,7 +237,23 @@ public class GroupingsRestControllerTest {
     @Test
     @WithMockUhUser
     public void membershipResultsTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + "members/groupings";
+        String uri = REST_CONTROLLER_BASE + "members/memberships";
+
+        given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.GET)))
+                .willReturn(new ResponseEntity(HttpStatus.OK));
+
+        assertNotNull(mockMvc.perform(get(uri))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        verify(httpRequestService, times(1))
+                .makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.GET));
+    }
+
+    @Test
+    @WithMockUhUser
+    public void managePersonResultsTest() throws Exception {
+        String uri = REST_CONTROLLER_BASE + "members/0000/groupings";
 
         given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.GET)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
@@ -254,7 +269,7 @@ public class GroupingsRestControllerTest {
     @Test
     @WithMockUhUser
     public void numberOfMembershipsTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + "/members/memberships";
+        String uri = REST_CONTROLLER_BASE + "members/memberships/count";
 
         given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.GET)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));
@@ -432,7 +447,7 @@ public class GroupingsRestControllerTest {
     @Test
     @WithMockUhUser
     public void numberOfGroupingsTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + "owners/grouping";
+        String uri = REST_CONTROLLER_BASE + "owners/groupings/count";
 
         given(httpRequestService.makeApiRequest(eq(USERNAME), anyString(), eq(HttpMethod.GET)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));

--- a/src/test/javascript/general.controller.test.js
+++ b/src/test/javascript/general.controller.test.js
@@ -48,10 +48,10 @@ describe("GeneralController", () => {
             httpBackend.whenGET(BASE_URL + "currentUser")
                 .respond(200, mockUser);
 
-            httpBackend.whenGET(BASE_URL + "members/memberships/")
+            httpBackend.whenGET(BASE_URL + "members/memberships/count")
                 .respond(200, mockResponse);
 
-            httpBackend.whenGET(BASE_URL + "owners/grouping/")
+            httpBackend.whenGET(BASE_URL + "owners/groupings/count")
                 .respond(200, mockResponse);
         });
 
@@ -67,25 +67,25 @@ describe("GeneralController", () => {
             expect(scope.currentUser).toEqual("jdoe");
         });
 
-        it("should make an API call to getNumberOfMembeships", () => {
-            httpBackend.expectGET(BASE_URL + "members/memberships/").respond(200, mockResponse);
+        it("should make an API call to getNumberOfMemberships", () => {
+            httpBackend.expectGET(BASE_URL + "members/memberships/count").respond(200, mockResponse);
             expect(httpBackend.flush).not.toThrow();
         });
 
         it("should initialize numberOfMemberships", () => {
-            httpBackend.expectGET(BASE_URL + "members/memberships/").respond(200, mockResponse);
+            httpBackend.expectGET(BASE_URL + "members/memberships/count").respond(200, mockResponse);
             httpBackend.flush();
 
             expect(scope.numberOfMemberships).toEqual(999);
         });
 
         it("should make an API call to getNumberOfGroupings", () => {
-            httpBackend.expectGET(BASE_URL + "owners/grouping/").respond(200, mockResponse);
+            httpBackend.expectGET(BASE_URL + "owners/groupings/count").respond(200, mockResponse);
             expect(httpBackend.flush).not.toThrow();
         });
 
         it("should initialize numberOfGroupings", () => {
-            httpBackend.expectGET(BASE_URL + "owners/grouping/").respond(200, mockResponse);
+            httpBackend.expectGET(BASE_URL + "owners/groupings/count").respond(200, mockResponse);
             httpBackend.flush();
 
             expect(scope.numberOfGroupings).toEqual(999);
@@ -1247,9 +1247,9 @@ describe("GeneralController", () => {
                 scope.userToAdd = "validUser";
                 httpBackend.whenGET(BASE_URL + "currentUser")
                     .respond(200);
-                httpBackend.whenGET(BASE_URL + "members/memberships/")
+                httpBackend.whenGET(BASE_URL + "members/memberships/count")
                     .respond(200);
-                httpBackend.whenGET(BASE_URL + "owners/grouping/")
+                httpBackend.whenGET(BASE_URL + "owners/groupings/count")
                     .respond(200);
                 httpBackend.whenGET(BASE_URL + "members/" + validUser.username)
                     .respond(200, validUser);
@@ -1277,9 +1277,9 @@ describe("GeneralController", () => {
             beforeEach(() => {
                 httpBackend.whenGET(BASE_URL + "currentUser")
                     .respond(200);
-                httpBackend.whenGET(BASE_URL + "members/memberships/")
+                httpBackend.whenGET(BASE_URL + "members/memberships/count")
                     .respond(200);
-                httpBackend.whenGET(BASE_URL + "owners/grouping/")
+                httpBackend.whenGET(BASE_URL + "owners/groupings/count")
                     .respond(200);
                 httpBackend.whenGET(BASE_URL + "members/" + "invalidUser")
                     .respond(200, invalidUser);

--- a/src/test/javascript/groupings.service.test.js
+++ b/src/test/javascript/groupings.service.test.js
@@ -305,7 +305,7 @@ describe("GroupingsService", function () {
 
         it("should use the correct path", function () {
             gs.getMembershipResults(onSuccess, onError);
-            httpBackend.expectGET(BASE_URL + "members/groupings/").respond(200);
+            httpBackend.expectGET(BASE_URL + "members/memberships/").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });
@@ -320,7 +320,7 @@ describe("GroupingsService", function () {
 
         it("should use the correct path", function () {
             gs.managePersonResults(member, onSuccess, onError);
-            httpBackend.expectGET(BASE_URL + "members/" + member + "/groupings/all").respond(200);
+            httpBackend.expectGET(BASE_URL + "members/" + member + "/groupings/").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });
@@ -334,7 +334,7 @@ describe("GroupingsService", function () {
 
         it("should use the correct path", function () {
             gs.getNumberOfMemberships(onSuccess, onError);
-            httpBackend.expectGET(BASE_URL + "members/memberships/").respond(200);
+            httpBackend.expectGET(BASE_URL + "members/memberships/count").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
 
@@ -469,7 +469,7 @@ describe("GroupingsService", function () {
         });
         it("should use the correct path", function () {
             gs.getNumberOfGroupings(onSuccess, onError);
-            httpBackend.expectGET(BASE_URL + "owners/grouping/").respond(200);
+            httpBackend.expectGET(BASE_URL + "owners/groupings/count").respond(200);
             expect(httpBackend.flush).not.toThrow();
         });
     });


### PR DESCRIPTION
# Ticket Link

[GROUPINGS-1298](https://uhawaii.atlassian.net/browse/GROUPINGS-1298)

Done in conjunction with https://github.com/uhawaii-system-its-ti-iam/uh-groupings-api/pull/395

# List of squashed commits

- Renames endpoints for membershipResults and managePersonResults
- Renames endpoints for getNumberOfGroupings and getNumberOfMemberships

# Test Checklist

- [X] Unit Tests Passed:
- [X] Jasmine Tests Passed:
- [X] General Visual Inspection:

