### PR TITLE
Improves wording of Add Members modal tooltips

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -107,16 +107,16 @@ screen.message.description.save = Save this description.
 screen.message.description.cancel = Revert to original description.
 
 # Add modal tooltips
-screen.message.modal.add.tooltip.inBasis.include=This member is in Basis; adding them to the Include will ensure their membership.
-screen.message.modal.add.tooltip.inBasis.exclude=This member is in Basis; adding them to the Exclude will exclude their membership.
-screen.message.modal.add.tooltip.not.inBasis.exclude=This member is not in Basis; adding them to the Exclude will prevent them from discovering this grouping.
-screen.message.modal.add.tooltip.inInclude=This member will be moved from the Include to the Exclude.
-screen.message.modal.add.tooltip.inExclude=This member will be moved from the Exclude to the Include.
-screen.message.modal.multi.add.tooltip.inBasis.include=Members in Basis will ensure their membership upon adding them to the Include.
-screen.message.modal.multi.add.tooltip.inBasis.exclude=Members in Basis will exclude their membership upon adding them to the Exclude.
-screen.message.modal.multi.add.tooltip.not.inBasis.exclude=Members in Basis will exclude their membership; those not in Basis will exclude them from discovering this grouping. 
-screen.message.modal.multi.add.tooltip.inInclude=Members in the Include will be moved to the Exclude.
-screen.message.modal.multi.add.tooltip.inExclude=Members in the Exclude will be moved to the Include.
+screen.message.modal.add.tooltip.inBasis.include=This member is in the Basis list; adding them to Include ensures they remain a member if they should be dropped from the Basis in the future.
+screen.message.modal.add.tooltip.inBasis.exclude=This member is in the Basis list; adding them to Exclude will exclude their membership.
+screen.message.modal.add.tooltip.inBasis.exclude.optIn=This member is not in the Basis list; adding them to Exclude will prevent them from discovering this grouping.
+screen.message.modal.add.tooltip.inInclude=This member is in the Include list; they will be removed from Include and added to the Exclude list.
+screen.message.modal.add.tooltip.inExclude=This member is in the Exclude list; they will be removed from Exclude and added to the Include list.
+screen.message.modal.multi.add.tooltip.inBasis.include=If a member is in the Basis list, adding them to Include ensures they remain members if they should be dropped from the Basis in the future.
+screen.message.modal.multi.add.tooltip.inBasis.exclude=If a member is in the Basis list, adding them to Exclude will exclude their membership
+screen.message.modal.multi.add.tooltip.inBasis.exclude.optIn=Adding a member to the Exclude list will ensure exclusion now and in the future should a member appear in the Basis.
+screen.message.modal.multi.add.tooltip.inInclude=If a member is in the Include list, they will be removed from Include and added to the Exclude list.
+screen.message.modal.multi.add.tooltip.inExclude=If a member is in the Exclude list, they will be removed from Exclude and added to the Include list.
 
 # Vertical nav tooltips in admin and owners page
 screen.message.common.tooltip.nav.members=List all members (Basis + Include - Exclude members)

--- a/src/main/resources/templates/modal/addModal.html
+++ b/src/main/resources/templates/modal/addModal.html
@@ -34,7 +34,7 @@
             <th th:utext="#{screen.message.modal.add.uhUserId}"></th>
             <th class="font-weight-normal modal-attributes">{{uhUuid}}</th>
         </tr>
-        <tr ng-if="listName !== 'owners'">
+        <tr ng-if="listName !== 'owners' && groupingBasis.length > 0">
             <th th:utext="#{screen.message.modal.add.inBasis}"></th>
             <th class="font-weight-normal modal-attributes">
                 {{ inBasis }}
@@ -48,7 +48,7 @@
                 </span>
                 <span class="fa fa-info-circle clickable" ng-if="inBasis === 'No' && listName === 'Exclude' && allowOptIn"
                       data-toggle="tooltip" data-boundary="window" onmouseover="$(this).tooltip('toggle')"
-                      th:title="#{screen.message.modal.add.tooltip.not.inBasis.exclude}" aria-hidden="true">
+                      th:title="#{screen.message.modal.add.tooltip.inBasis.exclude.optIn}" aria-hidden="true">
                 </span>
             </th>
         </tr>

--- a/src/main/resources/templates/modal/multiAddModal.html
+++ b/src/main/resources/templates/modal/multiAddModal.html
@@ -18,7 +18,7 @@
                     <th scope="col">Username</th>
                     <th scope="col">UH Number</th>
                     <th scope="col">Name</th>
-                    <th scope="col" class="text-center"  ng-if="listName !== 'owners'">
+                    <th scope="col" class="text-center" ng-if="listName !== 'owners' && groupingBasis.length > 0">
                         Basis
                         <span class="fa fa-info-circle clickable" ng-if="listName === 'Include'"
                               data-toggle="tooltip" data-boundary="window" onmouseover="$(this).tooltip('toggle')"
@@ -30,7 +30,7 @@
                         </span>
                         <span class="fa fa-info-circle clickable" ng-if="listName === 'Exclude' && allowOptIn"
                               data-toggle="tooltip" data-boundary="window" onmouseover="$(this).tooltip('toggle')"
-                              th:title="#{screen.message.modal.multi.add.tooltip.not.inBasis.exclude}" aria-hidden="true">
+                              th:title="#{screen.message.modal.multi.add.tooltip.inBasis.exclude.optIn}" aria-hidden="true">
                         </span>
                     </th>
                     <th scope="col" class="text-center" ng-if="listName !== 'owners' && listName === 'Exclude'">
@@ -64,7 +64,7 @@
                     </td>
                     <td>{{ person['uhUuid'] }}</td>
                     <td>{{ person['name'] }}</td>
-                    <td class="text-center" ng-if="listName !== 'owners'">
+                    <td class="text-center" ng-if="listName !== 'owners' && groupingBasis.length > 0">
                         {{ person['inBasis'] }}
                     </td>
                     <td class="text-center" ng-if="listName !== 'owners' && listName === 'Exclude'">


### PR DESCRIPTION
# Ticket Link

[Groupings-1353](https://uhawaii.atlassian.net/browse/GROUPINGS-1353)

# List of squashed commits

- Now when a grouping has 0 basis members, the basis row/column is removed from the addModal/multiAddModal

# Test Checklist

- [x] Unit Tests Passed:
- [x] Jasmine Tests Passed:
- [x] General Visual Inspection:

