### PR TITLE
Switch to JUnit 5

### DIFF
--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
@@ -1,10 +1,10 @@
 package edu.hawaii.its.api.controller;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,10 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,7 +46,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -58,7 +56,6 @@ import edu.hawaii.its.groupings.controller.WithMockUhUser;
 import edu.hawaii.its.groupings.exceptions.ApiServerHandshakeException;
 import edu.hawaii.its.groupings.util.JsonUtil;
 
-@RunWith(SpringRunner.class)
 @ActiveProfiles("localTest")
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class GroupingsRestControllerTest {
@@ -86,7 +83,7 @@ public class GroupingsRestControllerTest {
 
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(context)
                 .apply(springSecurity())

--- a/src/test/java/edu/hawaii/its/api/type/GroupingServiceResultExceptionTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/GroupingServiceResultExceptionTest.java
@@ -1,19 +1,19 @@
 package edu.hawaii.its.api.type;
 
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GroupingServiceResultExceptionTest extends GroupingsServiceResult {
 
     private GroupingsServiceResultException groupingsServiceResultException;
 
-    @Before
+    @BeforeEach
     public void setUp(){
         groupingsServiceResultException = new GroupingsServiceResultException();
     }
@@ -26,6 +26,6 @@ public class GroupingServiceResultExceptionTest extends GroupingsServiceResult {
         String test = "GroupingsServiceResult "+
                 "[action=404, resultCode=resultCode0]";
         String expected = test.replaceAll("\\\\","");
-        assertThat(groupingsServiceResultException.getGsr().toString(), equalTo(expected));
+        assertThat(groupingsServiceResultException.getGsr().toString(), is(expected));
     }
 }

--- a/src/test/java/edu/hawaii/its/api/type/GroupingsHTTPExceptionTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/GroupingsHTTPExceptionTest.java
@@ -1,20 +1,20 @@
 package edu.hawaii.its.api.type;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GroupingsHTTPExceptionTest extends RuntimeException {
 
     private GroupingsHTTPException groupingsHTTPexception;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         groupingsHTTPexception = new GroupingsHTTPException();
     }
@@ -26,7 +26,7 @@ public class GroupingsHTTPExceptionTest extends RuntimeException {
         assertNull(groupingsHTTPexception.getMessage());
         assertNull(groupingsHTTPexception.getCause());
         // Status code defaults to 0 if not set
-        assertThat(groupingsHTTPexception.getStatusCode(), equalTo(0));
+        assertThat(groupingsHTTPexception.getStatusCode(), is(0));
     }
 
     @Test
@@ -35,25 +35,25 @@ public class GroupingsHTTPExceptionTest extends RuntimeException {
         Exception e = new RuntimeException("Test Case");
 
         groupingsHTTPexception = new GroupingsHTTPException("Error", e, 1);
-        assertThat(groupingsHTTPexception.getMessage(), equalTo("Error"));
-        assertThat(groupingsHTTPexception.getCause(), equalTo(e));
-        assertThat(groupingsHTTPexception.getStatusCode(), equalTo(1));
+        assertThat(groupingsHTTPexception.getMessage(), is("Error"));
+        assertThat(groupingsHTTPexception.getCause(), is(e));
+        assertThat(groupingsHTTPexception.getStatusCode(), is(1));
         assertThat(groupingsHTTPexception.getExceptionMessage(), notNullValue());
         assertThat(groupingsHTTPexception.getStackTrace(), notNullValue());
 
         Exception e1 = new RuntimeException("File not found");
 
         groupingsHTTPexception = new GroupingsHTTPException("Error 1", e1);
-        assertThat(groupingsHTTPexception.getMessage(), equalTo("Error 1"));
-        assertThat(groupingsHTTPexception.getCause(), equalTo(e1));
-        assertThat(groupingsHTTPexception.getStatusCode(), equalTo(0));
+        assertThat(groupingsHTTPexception.getMessage(), is("Error 1"));
+        assertThat(groupingsHTTPexception.getCause(), is(e1));
+        assertThat(groupingsHTTPexception.getStatusCode(), is(0));
         assertThat(groupingsHTTPexception.getExceptionMessage(), notNullValue());
         assertThat(groupingsHTTPexception.getStackTrace(), notNullValue());
 
         groupingsHTTPexception = new GroupingsHTTPException("Error 2");
-        assertThat(groupingsHTTPexception.getMessage(), equalTo("Error 2"));
+        assertThat(groupingsHTTPexception.getMessage(), is("Error 2"));
         assertNull(groupingsHTTPexception.getCause());
-        assertThat(groupingsHTTPexception.getStatusCode(), equalTo(0));
+        assertThat(groupingsHTTPexception.getStatusCode(), is(0));
         assertThat(groupingsHTTPexception.getExceptionMessage(), nullValue());
         assertThat(groupingsHTTPexception.getStackTrace(), notNullValue());
     }

--- a/src/test/java/edu/hawaii/its/api/type/GroupingsServiceResultTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/GroupingsServiceResultTest.java
@@ -1,17 +1,17 @@
 package edu.hawaii.its.api.type;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GroupingsServiceResultTest {
 
     private GroupingsServiceResult groupingsServiceResult;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         groupingsServiceResult = new GroupingsServiceResult();
     }
@@ -21,7 +21,7 @@ public class GroupingsServiceResultTest {
         assertNotNull(groupingsServiceResult);
         groupingsServiceResult.setResultCode("resultCode");
         groupingsServiceResult.setAction("Action");
-        assertThat(groupingsServiceResult.getResultCode(), equalTo("resultCode"));
-        assertThat(groupingsServiceResult.getAction(), equalTo("Action"));
+        assertThat(groupingsServiceResult.getResultCode(), is("resultCode"));
+        assertThat(groupingsServiceResult.getAction(), is("Action"));
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/access/AnonymousUserTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/AnonymousUserTest.java
@@ -1,19 +1,19 @@
 package edu.hawaii.its.groupings.access;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AnonymousUserTest {
 
     private User user;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         user = new AnonymousUser();
     }

--- a/src/test/java/edu/hawaii/its/groupings/access/AuthorizationServiceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/AuthorizationServiceTest.java
@@ -1,10 +1,10 @@
 package edu.hawaii.its.groupings.access;
 
 import org.jasig.cas.client.authentication.SimplePrincipal;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import edu.hawaii.its.api.controller.GroupingsRestController;
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 import edu.hawaii.its.groupings.controller.WithMockUhUser;
@@ -14,21 +14,21 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.security.Principal;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {SpringBootWebApplication.class})
 public class AuthorizationServiceTest {
 
@@ -44,7 +44,7 @@ public class AuthorizationServiceTest {
     @Autowired
     private WebApplicationContext context;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         webAppContextSetup(context)
                 .apply(springSecurity())
@@ -74,7 +74,7 @@ public class AuthorizationServiceTest {
         RoleHolder roleHolder = authorizationService.fetchRoles(uhUuid, "test");
 
         // Check results.
-        assertThat(roleHolder.size(), equalTo(2));
+        assertThat(roleHolder.size(), is(2));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
         assertFalse(roleHolder.contains(Role.EMPLOYEE));
@@ -100,32 +100,32 @@ public class AuthorizationServiceTest {
         RoleHolder roleHolder = authorizationService.fetchRoles(uhUuid, "test");
 
         // Check results.
-        assertThat(roleHolder.size(), equalTo(4));
+        assertThat(roleHolder.size(), is(4));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
         assertTrue(roleHolder.contains(Role.OWNER));
         assertTrue(roleHolder.contains(Role.ADMIN));
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void fetch() {
         RoleHolder roleHolder = authorizationService.fetchRoles("10000001", "test");
-        assertThat(roleHolder.size(), equalTo(4));
+        assertThat(roleHolder.size(), is(4));
         assertTrue(roleHolder.contains(Role.ANONYMOUS)); // ???
         assertTrue(roleHolder.contains(Role.UH));
         assertTrue(roleHolder.contains(Role.EMPLOYEE));
         assertTrue(roleHolder.contains(Role.ADMIN));
 
         roleHolder = authorizationService.fetchRoles("10000004", "test");
-        assertThat(roleHolder.size(), equalTo(3));
+        assertThat(roleHolder.size(), is(3));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
         assertTrue(roleHolder.contains(Role.EMPLOYEE));
         assertFalse(roleHolder.contains(Role.ADMIN));
 
         roleHolder = authorizationService.fetchRoles("10000004", "test");
-        assertThat(roleHolder.size(), equalTo(3));
+        assertThat(roleHolder.size(), is(3));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
         assertTrue(roleHolder.contains(Role.EMPLOYEE));
@@ -133,14 +133,14 @@ public class AuthorizationServiceTest {
 
         // 10000005
         roleHolder = authorizationService.fetchRoles("10000005", "test");
-        assertThat(roleHolder.size(), equalTo(2));
+        assertThat(roleHolder.size(), is(2));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
         assertFalse(roleHolder.contains(Role.EMPLOYEE));
         assertFalse(roleHolder.contains(Role.ADMIN));
 
         roleHolder = authorizationService.fetchRoles("90000009", "test");
-        assertThat(roleHolder.size(), equalTo(2));
+        assertThat(roleHolder.size(), is(2));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
         assertFalse(roleHolder.contains(Role.EMPLOYEE));

--- a/src/test/java/edu/hawaii/its/groupings/access/RoleHolderTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/RoleHolderTest.java
@@ -1,27 +1,26 @@
 package edu.hawaii.its.groupings.access;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 public class RoleHolderTest {
 
     @Test
     public void basics() {
         RoleHolder roleHolder = new RoleHolder();
-        assertThat(roleHolder.size(), equalTo(0));
+        assertThat(roleHolder.size(), is(0));
         roleHolder.add(Role.ANONYMOUS);
-        assertThat(roleHolder.size(), equalTo(1));
+        assertThat(roleHolder.size(), is(1));
         roleHolder.add(Role.UH);
-        assertThat(roleHolder.size(), equalTo(2));
+        assertThat(roleHolder.size(), is(2));
         roleHolder.add(Role.EMPLOYEE);
-        assertThat(roleHolder.size(), equalTo(3));
+        assertThat(roleHolder.size(), is(3));
         roleHolder.add(Role.OWNER);
-        assertThat(roleHolder.size(), equalTo(4));
+        assertThat(roleHolder.size(), is(4));
         roleHolder.add(Role.ADMIN);
-        assertThat(roleHolder.size(), equalTo(5));
+        assertThat(roleHolder.size(), is(5));
 
         assertThat(roleHolder.toString(), containsString("ROLE_ANONYMOUS"));
         assertThat(roleHolder.toString(), containsString("ROLE_UH"));

--- a/src/test/java/edu/hawaii/its/groupings/access/RoleTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/RoleTest.java
@@ -1,12 +1,11 @@
 package edu.hawaii.its.groupings.access;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RoleTest {
 
@@ -21,9 +20,9 @@ public class RoleTest {
     public void find() {
         Role role = Role.find(Role.ADMIN.name());
         assertNotNull(role);
-        assertThat(role.name(), equalTo(Role.ADMIN.name()));
-        assertThat(role.longName(), equalTo(Role.ADMIN.longName()));
-        assertThat(role.toString(), equalTo("ROLE_ADMIN"));
+        assertThat(role.name(), is(Role.ADMIN.name()));
+        assertThat(role.longName(), is(Role.ADMIN.longName()));
+        assertThat(role.toString(), is("ROLE_ADMIN"));
         role = Role.find("non-existent-role");
         assertNull(role);
     }

--- a/src/test/java/edu/hawaii/its/groupings/access/UhCasAttributesTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/UhCasAttributesTest.java
@@ -1,14 +1,15 @@
 package edu.hawaii.its.groupings.access;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UhCasAttributesTest {
 
@@ -39,7 +40,7 @@ public class UhCasAttributesTest {
     public void loadMapInvalidValueType() {
         Map<Object, Object> map = new HashMap<>();
         map.put("uhUuid", "666666");
-        map.put("uid", new Integer(666));
+        map.put("uid", 666);
         UhCasAttributes attributes = new UhCasAttributes(map);
         assertThat(attributes.getUsername(), is(""));
         assertThat(attributes.getUhUuid(), is("666666"));
@@ -51,7 +52,7 @@ public class UhCasAttributesTest {
     public void loadMapInvalidKeyType() {
         Map<Object, Object> map = new HashMap<>();
         map.put("uhUuid", "666666");
-        map.put(new Integer(666), new Integer(666));
+        map.put(666, 666);
         UhCasAttributes attributes = new UhCasAttributes(map);
         assertThat(attributes.getUsername(), is(""));
         assertThat(attributes.getUhUuid(), is("666666"));
@@ -62,7 +63,7 @@ public class UhCasAttributesTest {
     @Test
     public void loadMapInvalidTypes() {
         Map<Object, Object> map = new HashMap<>();
-        map.put(new Integer(666), new Integer(666));
+        map.put(666, 666);
         UhCasAttributes attributes = new UhCasAttributes(map);
         assertThat(attributes.getUsername(), is(""));
         assertThat(attributes.getUhUuid(), is(""));
@@ -177,7 +178,7 @@ public class UhCasAttributesTest {
         map.put("uhUuid", "666666");
 
         Map<Long, java.util.Date> uidMap = new HashMap<>();
-        uidMap.put(new Long(666), new java.util.Date());
+        uidMap.put(666L, new java.util.Date());
         map.put("uid", uidMap);
 
         UhCasAttributes attributes = new UhCasAttributes(map);
@@ -209,12 +210,12 @@ public class UhCasAttributesTest {
         map.put("eduPersonAffiliation", "aff");
         UhCasAttributes attributes = new UhCasAttributes(map);
 
-        assertThat(attributes.getMap().size(), equalTo(5));
-        assertThat(attributes.getUid(), equalTo("duckart"));
-        assertThat(attributes.getUhUuid(), equalTo("666666"));
-        assertThat(attributes.getName(), equalTo("Frank"));
-        assertThat(attributes.getMail().get(0), equalTo("frank@example.com"));
-        assertThat(attributes.getAffiliation().get(0), equalTo("aff"));
+        assertThat(attributes.getMap().size(), is(5));
+        assertThat(attributes.getUid(), is("duckart"));
+        assertThat(attributes.getUhUuid(), is("666666"));
+        assertThat(attributes.getName(), is("Frank"));
+        assertThat(attributes.getMail().get(0), is("frank@example.com"));
+        assertThat(attributes.getAffiliation().get(0), is("aff"));
 
         assertThat(attributes.toString(), containsString("uid=duckart"));
     }

--- a/src/test/java/edu/hawaii/its/groupings/access/UserBuilderTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/UserBuilderTest.java
@@ -1,12 +1,12 @@
 package edu.hawaii.its.groupings.access;
 
+import org.jasig.cas.client.authentication.SimplePrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import edu.hawaii.its.api.controller.GroupingsRestController;
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 import edu.hawaii.its.groupings.controller.WithMockUhUser;
-import org.jasig.cas.client.authentication.SimplePrincipal;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.security.Principal;
@@ -23,17 +23,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
-
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class UserBuilderTest {
 
@@ -52,7 +53,7 @@ public class UserBuilderTest {
     @Autowired
     private WebApplicationContext context;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         webAppContextSetup(context)
                 .apply(springSecurity())
@@ -83,7 +84,7 @@ public class UserBuilderTest {
         User user = userBuilder.make(map);
 
         // Check results.
-        assertEquals(4, user.getAuthorities().size());
+        assertThat(user.getAuthorities().size(), is(4));
         assertTrue(user.hasRole(Role.ANONYMOUS));
         assertTrue(user.hasRole(Role.UH));
         assertTrue(user.hasRole(Role.ADMIN));
@@ -101,7 +102,7 @@ public class UserBuilderTest {
             userBuilder.make(map);
             fail("Should not reach here.");
         } catch (Exception e) {
-            assertThat(UsernameNotFoundException.class, equalTo(e.getClass()));
+            assertThat(e.getClass(), is(UsernameNotFoundException.class));
             assertThat(e.getMessage(), containsString("uid is empty"));
         }
     }
@@ -115,13 +116,15 @@ public class UserBuilderTest {
             userBuilder.make(map);
             fail("Should not reach here.");
         } catch (Exception e) {
-            assertThat(UsernameNotFoundException.class, equalTo(e.getClass()));
+            assertThat(e.getClass(), is(UsernameNotFoundException.class));
             assertThat(e.getMessage(), containsString("uid is empty"));
         }
     }
 
-    @Test(expected = UsernameNotFoundException.class)
+    @Test
     public void make() {
-        userBuilder.make(new HashMap<String, String>());
+        UsernameNotFoundException exception =
+            assertThrows(UsernameNotFoundException.class, () -> userBuilder.make(new HashMap<String, String>()));
+        assertNull(exception.getCause());
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/access/UserContextServiceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/UserContextServiceTest.java
@@ -2,18 +2,19 @@ package edu.hawaii.its.groupings.access;
 
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 import edu.hawaii.its.groupings.controller.WithMockUhUser;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-
-@RunWith(SpringRunner.class)
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class UserContextServiceTest {
 
@@ -23,24 +24,24 @@ public class UserContextServiceTest {
     @Test
     @WithMockUhUser(username = "admin", roles = { "ROLE_ADMIN" })
     public void basics() {
-        assertThat(userContextService.getCurrentUhUuid(), equalTo("12345678"));
-        assertThat(userContextService.getCurrentUid(), equalTo("admin"));
-        assertThat(userContextService.toString(), startsWith("UserContextServiceImpl"));
+        assertThat("12345678", is(userContextService.getCurrentUhUuid()));
+        assertThat("admin", is(userContextService.getCurrentUid()));
+        assertTrue(userContextService.toString().startsWith("UserContextServiceImpl"));
 
         User user = userContextService.getCurrentUser();
         assertNotNull(user);
-        assertThat(user.getUhUuid(), equalTo("12345678"));
-        assertThat(user.getUid(), equalTo("admin"));
+        assertThat("12345678", is(user.getUhUuid()));
+        assertThat("admin", is(user.getUid()));
 
         userContextService.setCurrentUhUuid("87654321");
-        assertThat(userContextService.getCurrentUhUuid(), equalTo("87654321"));
+        assertThat("87654321", is(userContextService.getCurrentUhUuid()));
     }
     @Test
     @WithMockUhUser(username = "Owner", roles = { "ROLE_OWNER"})
     public void testOwner(){
         User user = userContextService.getCurrentUser();
-        assertThat(user.hasRole(Role.ADMIN), equalTo(false));
-        assertThat(user.hasRole(Role.OWNER), equalTo(true));
+        assertFalse(user.hasRole(Role.ADMIN));
+        assertTrue(user.hasRole(Role.OWNER));
     }
 }
 

--- a/src/test/java/edu/hawaii/its/groupings/access/UserDetailsServiceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/UserDetailsServiceTest.java
@@ -5,8 +5,7 @@ import org.jasig.cas.client.authentication.AttributePrincipalImpl;
 import org.jasig.cas.client.authentication.SimplePrincipal;
 import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.AssertionImpl;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import edu.hawaii.its.api.controller.GroupingsRestController;
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 
@@ -16,24 +15,23 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(SpringRunner.class)
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class UserDetailsServiceTest {
 
@@ -84,12 +82,12 @@ public class UserDetailsServiceTest {
         User user = (User) userDetailsService.loadUserDetails(assertion);
 
         // Basics.
-        assertThat(user.getUsername(), equalTo("levia"));
-        assertThat(user.getUid(), equalTo("levia"));
-        assertThat(user.getUhUuid(), equalTo("89999999"));
+        assertThat(user.getUsername(), is("levia"));
+        assertThat(user.getUid(), is("levia"));
+        assertThat(user.getUhUuid(), is("89999999"));
 
         // Granted Authorities.
-        assertThat(user.getAuthorities().size(), equalTo(4));
+        assertThat(user.getAuthorities().size(), is(4));
         assertTrue(user.hasRole(Role.ANONYMOUS));
         assertTrue(user.hasRole(Role.UH));
         assertTrue(user.hasRole(Role.OWNER));
@@ -123,12 +121,12 @@ public class UserDetailsServiceTest {
         User user = (User) userDetailsService.loadUserDetails(assertion);
 
         // Basics.
-        assertThat(user.getUsername(), equalTo("jjcale"));
-        assertThat(user.getUid(), equalTo("jjcale"));
-        assertThat(user.getUhUuid(), equalTo("90000000"));
+       assertThat(user.getUsername(), is("jjcale"));
+       assertThat(user.getUid(), is("jjcale"));
+       assertThat(user.getUhUuid(), is("90000000"));
 
         // Granted Authorities.
-        assertThat(user.getAuthorities().size(), equalTo(3));
+       assertThat(user.getAuthorities().size(), is(3));
         assertTrue(user.hasRole(Role.ANONYMOUS));
         assertTrue(user.hasRole(Role.UH));
         assertTrue(user.hasRole(Role.OWNER));
@@ -148,8 +146,8 @@ public class UserDetailsServiceTest {
             userDetailsService.loadUserDetails(assertion);
             fail("Should not have reached here.");
         } catch (Exception e) {
-            assertThat(UsernameNotFoundException.class, equalTo(e.getClass()));
-            assertThat(e.getMessage(), containsString("principal is null"));
+           assertThat(UsernameNotFoundException.class, is(e.getClass()));
+           assertThat(e.getMessage(), containsString("principal is null"));
         }
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/access/UserTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/UserTest.java
@@ -1,6 +1,6 @@
 package edu.hawaii.its.groupings.access;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
@@ -9,10 +9,11 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UserTest {
 
@@ -55,9 +56,9 @@ public class UserTest {
         User user = new User("a", authorities);
         user.setAttributes(new UhCasAttributes(map));
 
-        assertThat(user.getAttribute("uid"), equalTo("duckart"));
-        assertThat(user.getName(), equalTo("Frank6"));
-        assertThat(user.getGivenName(), equalTo("Frank"));
+        assertThat(user.getAttribute("uid"), is("duckart"));
+        assertThat(user.getName(), is("Frank6"));
+        assertThat(user.getGivenName(), is("Frank"));
         assertThat(user.toString(), containsString("uid=a"));
         assertThat(user.toString(), containsString("uhUuid=null"));
     }

--- a/src/test/java/edu/hawaii/its/groupings/configuration/AppConfigRunTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/AppConfigRunTest.java
@@ -1,13 +1,12 @@
 package edu.hawaii.its.groupings.configuration;
 
-import static org.junit.Assert.assertNotNull;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(SpringRunner.class)
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class AppConfigRunTest {
 

--- a/src/test/java/edu/hawaii/its/groupings/configuration/GrouperPropertyConfigurerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/GrouperPropertyConfigurerTest.java
@@ -1,20 +1,19 @@
 package edu.hawaii.its.groupings.configuration;
 
 import edu.internet2.middleware.grouperClient.util.GrouperClientConfig;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {SpringBootWebApplication.class})
 public class GrouperPropertyConfigurerTest {
 
@@ -44,6 +43,6 @@ public class GrouperPropertyConfigurerTest {
         grouperPropertyConfigurer.init();
 
         value = config.propertiesOverrideMap().get(key);
-        assertThat(value, equalTo(testUrl));
+        assertEquals(testUrl, value);
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/configuration/RealmTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/RealmTest.java
@@ -1,16 +1,17 @@
 package edu.hawaii.its.groupings.configuration;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(SpringRunner.class)
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class RealmTest {
 

--- a/src/test/java/edu/hawaii/its/groupings/configuration/SecurityConfigTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/SecurityConfigTest.java
@@ -1,14 +1,13 @@
 package edu.hawaii.its.groupings.configuration;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertNotNull;
-
-@RunWith(SpringRunner.class)
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class SecurityConfigTest {
 

--- a/src/test/java/edu/hawaii/its/groupings/controller/ErrorControllerAdviceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/controller/ErrorControllerAdviceTest.java
@@ -1,14 +1,13 @@
 package edu.hawaii.its.groupings.controller;
 
-import org.junit.runner.RunWith;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.*;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.lang.NonNull;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -22,7 +21,10 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 
-@RunWith(SpringRunner.class)
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class ErrorControllerAdviceTest {
 
@@ -35,12 +37,12 @@ public class ErrorControllerAdviceTest {
     }
 
     @Test
-    public void gcWebServiceTest() throws Exception {
+    public void gcWebServiceTest() {
         Object Ro = new Object();
         GcWebServiceError Gc = new GcWebServiceError(Ro);
         errorControllerAdvice.handleGcWebServiceError(Gc);
         String gce = "<404,edu.hawaii.its.api.type.GroupingsHTTPException,[]>";
-        assertThat(errorControllerAdvice.handleGcWebServiceError(Gc).toString(), equalTo(gce));
+        assertThat(errorControllerAdvice.handleGcWebServiceError(Gc).toString(), is(gce));
     }
 
     @Test
@@ -55,7 +57,7 @@ public class ErrorControllerAdviceTest {
                 return new String[0];
             }
 
-            @Override public Iterator<String> getHeaderNames() {
+            @Override @NonNull public Iterator<String> getHeaderNames() {
                 return null;
             }
 
@@ -150,7 +152,8 @@ public class ErrorControllerAdviceTest {
         errorControllerAdvice.handleIllegalArgumentException(IAE, Req);
         String IAException = "<404,edu.hawaii.its.api.type.GroupingsHTTPException: "
                 + "Resource not available,[]>";
-        assertThat(errorControllerAdvice.handleIllegalArgumentException(IAE, Req).toString(), equalTo(IAException));
+        assertThat(errorControllerAdvice.handleIllegalArgumentException(IAE, Req).toString(),
+                is(IAException));
 
     }
 
@@ -160,7 +163,8 @@ public class ErrorControllerAdviceTest {
         errorControllerAdvice.handleUnsupportedOperationException(UOE);
         String UnOpE = "<501,edu.hawaii.its.api.type.GroupingsHTTPException: "
                 + "Method not implemented,[]>";
-        assertThat(errorControllerAdvice.handleUnsupportedOperationException(UOE).toString(), equalTo(UnOpE));
+        assertThat(errorControllerAdvice.handleUnsupportedOperationException(UOE).toString(),
+                is(UnOpE));
 
     }
 
@@ -170,7 +174,7 @@ public class ErrorControllerAdviceTest {
       errorControllerAdvice.handleException(re);
       String runtime = "<500,edu.hawaii.its.api.type.GroupingsHTTPException:"
           + " Exception,[]>";
-      assertThat(errorControllerAdvice.handleException(re).toString(), equalTo(runtime));
+      assertThat(errorControllerAdvice.handleException(re).toString(), is(runtime));
     }
 
     @Test
@@ -179,7 +183,7 @@ public class ErrorControllerAdviceTest {
         errorControllerAdvice.handleException(E);
         String exception = "<500,edu.hawaii.its.api.type.GroupingsHTTPException: "
                 + "Exception,[]>";
-        assertThat(errorControllerAdvice.handleException(E).toString(), equalTo(exception));
+        assertThat(errorControllerAdvice.handleException(E).toString(), is(exception));
     }
 
     @Test
@@ -188,13 +192,14 @@ public class ErrorControllerAdviceTest {
         errorControllerAdvice.handleGroupingsServiceResultException(GSRE);
         String SRE = "<400,edu.hawaii.its.api.type.GroupingsHTTPException: "
                 + "Groupings Service resulted in FAILURE,[]>";
-        assertThat(errorControllerAdvice.handleGroupingsServiceResultException(GSRE).toString(), equalTo(SRE));
+        assertThat(errorControllerAdvice.handleGroupingsServiceResultException(GSRE).toString(),
+                is(SRE));
     }
 
     @Test
     public void typeMismatchTest() {
         Exception E1 = new Exception();
         errorControllerAdvice.handleTypeMismatchException(E1);
-        assertThat(errorControllerAdvice.handleTypeMismatchException(E1), equalTo("redirect:/error"));
+        assertThat(errorControllerAdvice.handleTypeMismatchException(E1), is("redirect:/error"));
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/controller/ErrorRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/controller/ErrorRestControllerTest.java
@@ -2,26 +2,26 @@ package edu.hawaii.its.groupings.controller;
 
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 import edu.hawaii.its.groupings.type.Feedback;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.http.HttpSession;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class ErrorRestControllerTest {
 
@@ -33,7 +33,7 @@ public class ErrorRestControllerTest {
 
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(context).build();
     }
@@ -53,9 +53,10 @@ public class ErrorRestControllerTest {
                 .getRequest()
                 .getSession();
 
+        assert session != null;
         assertNotNull(session.getAttribute("feedback"));
         Feedback feedback = (Feedback) session.getAttribute("feedback");
-        assertThat(feedback.getExceptionMessage(), equalTo("exception"));
+        assertThat(feedback.getExceptionMessage(), is("exception"));
     }
 
 }

--- a/src/test/java/edu/hawaii/its/groupings/controller/HomeControllerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/controller/HomeControllerTest.java
@@ -3,15 +3,15 @@ package edu.hawaii.its.groupings.controller;
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 import edu.hawaii.its.groupings.type.Feedback;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -19,12 +19,12 @@ import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.http.HttpSession;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @ActiveProfiles("localTest")
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class HomeControllerTest {
 
@@ -56,7 +56,7 @@ public class HomeControllerTest {
 
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(context)
                 .apply(springSecurity())
@@ -131,7 +131,7 @@ public class HomeControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(status().is(302))
                 .andReturn();
-        assertThat(mvcResult.getResponse().getRedirectedUrl(), equalTo(appUrlHome));
+        assertThat(mvcResult.getResponse().getRedirectedUrl(), is(appUrlHome));
     }
 
     @Test
@@ -229,7 +229,7 @@ public class HomeControllerTest {
     public void requestFeedbackWithoutException() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/feedback"))
                 .andExpect(status().isOk())
-                .andExpect(model().attribute("feedback", hasProperty("email", equalTo("user@hawaii.edu"))))
+                .andExpect(model().attribute("feedback", hasProperty("email", is("user@hawaii.edu"))))
                 .andExpect(model().attribute("feedback", hasProperty("exceptionMessage", nullValue())))
                 .andExpect(model().attributeExists("feedback"))
                 .andReturn();
@@ -243,11 +243,13 @@ public class HomeControllerTest {
                 .sessionAttr("feedback", new Feedback("exception")))
                 .andExpect(status().isOk())
                 .andExpect(model().attributeExists("feedback"))
-                .andExpect(model().attribute("feedback", hasProperty("exceptionMessage", equalTo("exception"))))
-                .andExpect(model().attribute("feedback", hasProperty("email", equalTo("user@hawaii.edu"))))
+                .andExpect(model().attribute("feedback", hasProperty("exceptionMessage", is("exception"))))
+                .andExpect(model().attribute("feedback", hasProperty("email", is("user@hawaii.edu"))))
                 .andReturn()
                 .getRequest()
                 .getSession();
+
+        assert session != null;
         assertThat(session.getAttribute("feedback"), notNullValue());
     }
 
@@ -259,7 +261,7 @@ public class HomeControllerTest {
                 .flashAttr("feedback", new Feedback()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/feedback"))
-                .andExpect(flash().attribute("success", equalTo(true)))
+                .andExpect(flash().attribute("success", is(true)))
                 .andReturn();
         assertNotNull(mvcResult);
     }

--- a/src/test/java/edu/hawaii/its/groupings/exceptions/ApiServerHandshakeAnalyzerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/exceptions/ApiServerHandshakeAnalyzerTest.java
@@ -1,11 +1,11 @@
 package edu.hawaii.its.groupings.exceptions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ApiServerHandshakeAnalyzerTest {
 
@@ -16,9 +16,7 @@ public class ApiServerHandshakeAnalyzerTest {
 
         FailureAnalysis fa = analyzer.analyze(null, null);
         assertNotNull(fa);
-        assertThat(fa.getDescription(),
-                startsWith("Could not connect to the API server"));
-        assertThat(fa.getAction(),
-                startsWith("Start the UH Groupings API"));
+        assertThat(fa.getDescription(), startsWith("Could not connect to the API server"));
+        assertThat(fa.getAction(), startsWith("Start the UH Groupings API"));
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/exceptions/ApiServerHandshakeExceptionTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/exceptions/ApiServerHandshakeExceptionTest.java
@@ -1,11 +1,11 @@
 package edu.hawaii.its.groupings.exceptions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ApiServerHandshakeExceptionTest {
 
@@ -13,13 +13,13 @@ public class ApiServerHandshakeExceptionTest {
     public void construction() {
         InitializationException ex = new ApiServerHandshakeException("fail");
         assertNotNull(ex);
-        assertThat(ex.getMessage(), equalTo("fail"));
+        assertThat(ex.getMessage(), is("fail"));
 
         ex = new ApiServerHandshakeException("stop", new Throwable("me"));
         assertNotNull(ex);
         assertThat(ex.getCause(), instanceOf(Throwable.class));
         String expected = "stop; nested exception is java.lang.Throwable: me";
-        assertThat(ex.getMessage(), equalTo(expected));
-        assertThat(ex.getLocalizedMessage(), equalTo(expected));
+        assertThat(ex.getMessage(), is(expected));
+        assertThat(ex.getLocalizedMessage(), is(expected));
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/service/EmailServiceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/service/EmailServiceTest.java
@@ -2,22 +2,22 @@ package edu.hawaii.its.groupings.service;
 
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 import edu.hawaii.its.groupings.type.Feedback;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class EmailServiceTest {
 
@@ -37,7 +37,7 @@ public class EmailServiceTest {
         return feedback;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         JavaMailSender sender = new MockJavaMailSender() {
             @Override

--- a/src/test/java/edu/hawaii/its/groupings/service/PasswordScannerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/service/PasswordScannerTest.java
@@ -7,8 +7,8 @@ import edu.hawaii.its.groupings.exceptions.PasswordFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class PasswordScannerTest {

--- a/src/test/java/edu/hawaii/its/groupings/service/PatternPropertyCheckerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/service/PatternPropertyCheckerTest.java
@@ -18,8 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PatternPropertyCheckerTest {
 
     private PatternPropertyChecker patternPropertyChecker;
-    private Path resourceDir = Paths.get("src", "test", "resources", "pattern-property-checker");
-    private String dirname = resourceDir.toString();
+    private final Path resourceDir = Paths.get("src", "test", "resources", "pattern-property-checker");
+    private final String dirname = resourceDir.toString();
 
     @BeforeEach
     public void setUp() {
@@ -56,7 +56,7 @@ public class PatternPropertyCheckerTest {
         List<String> fileLocations = patternPropertyChecker.getPatternLocation(dirname, ".properties");
         assertEquals(1, fileLocations.size());
         Path path = Paths.get(resourceDir.toString(), "test1", "PatternPropertyCheckerTestFile.properties");
-        assertThat(fileLocations.get(0), endsWith(path.toString() + " on line: 2"));
+        assertThat(fileLocations.get(0), endsWith(path + " on line: 2"));
     }
 
     @Test
@@ -65,8 +65,8 @@ public class PatternPropertyCheckerTest {
         List<String> fileLocations = patternPropertyChecker.getPatternLocation(dirname, ".properties");
         assertEquals(2, fileLocations.size());
         Path path = Paths.get(resourceDir.toString(), "test2", "PatternPropertyCheckerTestFile2.properties");
-        assertThat(fileLocations.get(0), endsWith(path.toString() + " on line: 2"));
-        assertThat(fileLocations.get(1), endsWith(path.toString() + " on line: 5"));
+        assertThat(fileLocations.get(0), endsWith(path + " on line: 2"));
+        assertThat(fileLocations.get(1), endsWith(path + " on line: 5"));
     }
 
     @Test
@@ -77,8 +77,8 @@ public class PatternPropertyCheckerTest {
         Path path1 = Paths.get(resourceDir.toString(), "test1", "PatternPropertyCheckerTwoPatterns.txt");
         Path path2 = Paths.get(resourceDir.toString(), "test1", "PatternPropertyCheckerTwoPatterns2.txt");
 
-        assertThat(fileLocations.get(0), endsWith(path1.toString() + " on line: 1"));
-        assertThat(fileLocations.get(1), endsWith(path2.toString() + " on line: 3"));
+        assertThat(fileLocations.get(0), endsWith(path1 + " on line: 1"));
+        assertThat(fileLocations.get(1), endsWith(path2 + " on line: 3"));
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/groupings/type/EmployeeTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/type/EmployeeTest.java
@@ -1,19 +1,19 @@
 package edu.hawaii.its.groupings.type;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class EmployeeTest {
 
     private Employee employee;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         employee = new Employee();
     }
@@ -24,7 +24,7 @@ public class EmployeeTest {
         assertNull(employee.getUhUuid());
 
         employee = new Employee(123456789L);
-        assertThat(employee.getUhUuid(), equalTo(123456789L));
+        assertThat(employee.getUhUuid(), is(123456789L));
     }
 
     @Test
@@ -34,7 +34,7 @@ public class EmployeeTest {
         assertNotNull(employee.toString());
 
         employee.setUhUuid(12345678L);
-        assertThat(employee.getUhUuid(), equalTo(12345678L));
+        assertThat(employee.getUhUuid(), is(12345678L));
         assertThat(employee.toString(), containsString("uhUuid=12345678"));
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/type/FeedbackTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/type/FeedbackTest.java
@@ -1,19 +1,19 @@
 package edu.hawaii.its.groupings.type;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FeedbackTest {
 
     private Feedback feedback;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         feedback = new Feedback();
     }
@@ -33,11 +33,11 @@ public class FeedbackTest {
         feedback.setMessage("Test Message");
         feedback.setExceptionMessage("Exception Message");
 
-        assertThat(feedback.getName(), equalTo("Test User"));
-        assertThat(feedback.getEmail(), equalTo("test@hawaii.edu"));
-        assertThat(feedback.getType(), equalTo("Problem"));
-        assertThat(feedback.getMessage(), equalTo("Test Message"));
-        assertThat(feedback.getExceptionMessage(), equalTo("Exception Message"));
+        assertThat(feedback.getName(), is("Test User"));
+        assertThat(feedback.getEmail(), is("test@hawaii.edu"));
+        assertThat(feedback.getType(), is("Problem"));
+        assertThat(feedback.getMessage(), is("Test Message"));
+        assertThat(feedback.getExceptionMessage(), is("Exception Message"));
 
         assertThat(feedback.toString(), containsString("email=test@hawaii.edu"));
         assertThat(feedback.toString(), containsString("exceptionMessage=Exception Message"));
@@ -52,7 +52,7 @@ public class FeedbackTest {
         assertNull(feedback.getEmail());
         assertNull(feedback.getType());
         assertNull(feedback.getMessage());
-        assertThat(feedback.getExceptionMessage(), equalTo("Test Exception Stack Trace"));
+        assertThat(feedback.getExceptionMessage(), is("Test Exception Stack Trace"));
 
         assertThat(feedback.toString(), containsString("exceptionMessage=Test Exception Stack Trace"));
     }

--- a/src/test/java/edu/hawaii/its/groupings/type/MessageTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/type/MessageTest.java
@@ -1,19 +1,18 @@
 package edu.hawaii.its.groupings.type;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MessageTest {
 
     private Message message;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         message = new Message();
     }
@@ -32,7 +31,7 @@ public class MessageTest {
         assertNull(message.getTypeId());
 
         message.setId(666);
-        assertThat(message.getId(), equalTo(666));
+        assertThat(message.getId(), is(666));
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/groupings/type/OwnerTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/type/OwnerTest.java
@@ -1,17 +1,19 @@
 package edu.hawaii.its.groupings.type;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 
 public class OwnerTest {
 
     private Owner owner;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         owner = new Owner();
     }
@@ -19,35 +21,35 @@ public class OwnerTest {
     @Test
     public void construction() {
         owner = new Owner("James T Kirk");
-        assertThat(owner.getPrivilegeName(), equalTo("James T Kirk"));
+        assertThat(owner.getPrivilegeName(), is("James T Kirk"));
     }
 
     @Test
     public void name() {
-        assertThat(owner.getName(), equalTo(null));
+        assertNull(owner.getName());
         owner.setName("frank");
-        assertThat(owner.getName(), equalTo("frank"));
+        assertThat(owner.getName(), is("frank"));
     }
 
     @Test
     public void privilegeName() {
-        assertThat(owner.getPrivilegeName(), equalTo(null));
+        assertNull(owner.getPrivilegeName());
         owner.setPrivilegeName("frd");
-        assertThat(owner.getPrivilegeName(), equalTo("frd"));
+        assertThat(owner.getPrivilegeName(), is("frd"));
     }
 
     @Test
     public void uhUuid() {
-        assertThat(owner.getUhUuid(), equalTo(null));
+        assertNull(owner.getUhUuid());
         owner.setUhUuid("uhUuid");
-        assertThat(owner.getUhUuid(), equalTo("uhUuid"));
+        assertThat(owner.getUhUuid(), is("uhUuid"));
     }
 
     @Test
     public void uid() {
-        assertThat(owner.getUid(), equalTo(null));
+        assertNull(owner.getUid());
         owner.setUid("uid");
-        assertThat(owner.getUid(), equalTo("uid"));
+        assertThat(owner.getUid(), is("uid"));
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/groupings/type/TypeTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/type/TypeTest.java
@@ -1,19 +1,19 @@
 package edu.hawaii.its.groupings.type;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TypeTest {
 
     private Type type;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         type = new Type();
     }
@@ -33,9 +33,9 @@ public class TypeTest {
         type.setId(666);
         type.setDescription("The Beast");
         type.setVersion(9);
-        assertThat(type.getId(), equalTo(666));
-        assertThat(type.getDescription(), equalTo("The Beast"));
-        assertThat(type.getVersion(), equalTo(9));
+        assertThat(type.getId(), is(666));
+        assertThat(type.getDescription(), is("The Beast"));
+        assertThat(type.getVersion(), is(9));
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/groupings/type/UserRoleTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/type/UserRoleTest.java
@@ -1,19 +1,19 @@
 package edu.hawaii.its.groupings.type;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class UserRoleTest {
 
     private UserRole userRole;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         userRole = new UserRole();
     }
@@ -34,9 +34,9 @@ public class UserRoleTest {
         userRole.setId(666);
         userRole.setAuthority("The Beast");
         userRole.setVersion(9);
-        assertThat(userRole.getId(), equalTo(666));
-        assertThat(userRole.getAuthority(), equalTo("The Beast"));
-        assertThat(userRole.getVersion(), equalTo(9));
+        assertThat(userRole.getId(), is(666));
+        assertThat(userRole.getAuthority(), is("The Beast"));
+        assertThat(userRole.getVersion(), is(9));
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/groupings/util/DatesTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/util/DatesTest.java
@@ -2,8 +2,9 @@ package edu.hawaii.its.groupings.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -15,8 +16,8 @@ import java.time.Month;
 import java.util.Calendar;
 import java.util.Date;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class DatesTest {
@@ -29,7 +30,7 @@ public class DatesTest {
     protected Date dayMusicDiedDate;
     protected Date newYearsDay2000Date;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         christmasLocalDate = LocalDate.of(1962, Month.DECEMBER, 25);
         newYearsDay2000LocalDate = LocalDate.of(2000, Month.JANUARY, 1);
@@ -68,12 +69,13 @@ public class DatesTest {
             cal.add(Calendar.DATE, -13); // Move back some days.
             final LocalDate date2 = Dates.toLocalDate(cal.getTime());
 
+            assert date2 != null;
             final LocalDate sunday = Dates.previousSunday(date2);
             Calendar calSunday = Calendar.getInstance();
             calSunday.setTime(Dates.toDate(sunday));
 
             assertThat(calSunday.get(Calendar.DAY_OF_WEEK), is(Calendar.SUNDAY));
-            assertTrue(sunday.compareTo(date2) <= 0);
+            assertFalse(sunday.isAfter(date2));
         }
 
         LocalDate date4 = Dates.previousSunday(christmasLocalDate);

--- a/src/test/java/edu/hawaii/its/groupings/util/StringsTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/util/StringsTest.java
@@ -1,18 +1,17 @@
 package edu.hawaii.its.groupings.util;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StringsTest {
 
@@ -45,12 +44,12 @@ public class StringsTest {
     @Test
     public void trunctate() {
         String s = "abcdefghijk";
-        assertThat(Strings.truncate(s, 3), equalTo("abc"));
-        assertThat(Strings.truncate(s, 2), equalTo("ab"));
-        assertThat(Strings.truncate(s, 1), equalTo("a"));
-        assertThat(Strings.truncate(s, 0), equalTo(""));
-        assertThat(Strings.truncate(s, 11), equalTo(s));
-        assertThat(Strings.truncate(s, 12), equalTo(s));
+        assertThat(Strings.truncate(s, 3), is("abc"));
+        assertThat(Strings.truncate(s, 2), is("ab"));
+        assertThat(Strings.truncate(s, 1), is("a"));
+        assertThat(Strings.truncate(s, 0), is(""));
+        assertThat(Strings.truncate(s, 11), is(s));
+        assertThat(Strings.truncate(s, 12), is(s));
 
         assertNull(Strings.truncate(null, 0));
         assertNull(Strings.truncate(null, 1));


### PR DESCRIPTION
# Ticket Link

[Ticket GROUPINGS-1340](https://uhawaii.atlassian.net/browse/GROUPINGS-1340)

# List of squashed commits

- Migrate GroupingsRestControllerTest to Junit5
- Change GroupingServiceResultException to Junit5
- Change GroupingsHTTPExceptionTest to Junit5
- Change GroupingsServiceResultTest to Junit5
- Change AnnoymousUserTest to Junit5
- AuthorizationServiceTest to Junit5
- RoleHolderTest to Junit5
- RoleTest to Junit5
- UhCasAttributesTest to Junit5
- UserBuilderTest to Junit5
- UserContextServiceTest to Junit5
- UserDetailsServiceTest to Junit5
- UserTest to Junit5
- WIP errors with Zak
- Resolve UserBuilderTest Junit4 methods not found
- UserContextServiceTest and UserTest to Junit5
- UserBuilderTest assertThat containsString
- UserContextServiceTest and groupings/configuration files to Junit5 except SecurityConfigTest
- Add back @RunWith statements
- UserBuilderTest Matcher assertThat
- UhCasAttributesTest to UserTest assertThat and @ExtendWith
- AppConfigRunTest @ExtendWith
- Up to SecurityConfigTest to Junit5
- Revisions to use Matcher assertThat and depreciated values
- Controller folder
- Exceptions, service, and type folder
- Changes imports and tests of JsonUtilTest and StringsTest
- JsonUtilTest to pass
- Access folder finalized
- Configuration finalized
- Controller finalized
- Exceptions finalized
- Service finalized
- Type finalized and previous files use 'is'
- Util finalized

# Test Checklist

- [x] Unit Tests Passed:
- [x] Jasmine Tests Passed:
- [x] General Visual Inspection:

