### PR TITLE
Add icon to the nav bar - indicate user is not in their personal account

### DIFF
--- a/src/main/java/edu/hawaii/its/groupings/access/AuthorizationService.java
+++ b/src/main/java/edu/hawaii/its/groupings/access/AuthorizationService.java
@@ -7,7 +7,6 @@ import edu.hawaii.its.api.controller.GroupingsRestController;
 import edu.hawaii.its.groupings.service.UhUuidCheckerService;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -37,6 +36,9 @@ public class AuthorizationService {
             roleHolder.add(Role.UH);
         }
 
+        if (uhUuidCheckerService.isDepartmentAccount(uhUuid, uid)) {
+            roleHolder.add(Role.DEPARTMENT);
+        }
         //Determine if user is an owner.
         if (checkResult(groupingsRestController.hasOwnerPrivs(principal))) {
             roleHolder.add(Role.OWNER);

--- a/src/main/java/edu/hawaii/its/groupings/access/Role.java
+++ b/src/main/java/edu/hawaii/its/groupings/access/Role.java
@@ -5,7 +5,8 @@ public enum Role {
     UH,
     EMPLOYEE,
     OWNER,
-    ADMIN;
+    ADMIN,
+    DEPARTMENT;
 
     public String longName() {
         return "ROLE_" + name();

--- a/src/main/java/edu/hawaii/its/groupings/service/UhUuidCheckerService.java
+++ b/src/main/java/edu/hawaii/its/groupings/service/UhUuidCheckerService.java
@@ -1,12 +1,13 @@
 package edu.hawaii.its.groupings.service;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class UhUuidCheckerService {
@@ -22,5 +23,10 @@ public class UhUuidCheckerService {
 
         final Matcher matcher = pattern.matcher(uhUuid);
         return matcher.matches() || uhUuid.equals(uid);
+    }
+
+    public boolean isDepartmentAccount(String uhUuid, String uid) {
+        logger.info(String.format("isDepartmentAccount; uhUuid: %s; uid: %s", uhUuid, uid));
+        return uhUuid.equals(uid);
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -7,6 +7,7 @@ screen.message.home.page.groupingData=Leverage group data from official sources,
 screen.message.home.page.adminInfo=Manage the list of Administrators for this service. Search for and manage any grouping on behalf of the owner.
 screen.message.home.page.membershipInfo=View and manage my memberships. Search for new groupings to join as a member.
 screen.message.home.page.mygroupingsInfo=View and manage groupings I own. Manage members, configure grouping options and sync destinations.
+screen.message.home.page.departmentAccount=You are not in your personal account.
 
 # Admin Page
 screen.message.admin.page.description=Search for and manage any grouping on behalf of its owner. Manage the list of UH Groupings administrators.

--- a/src/main/resources/templates/menubar.html
+++ b/src/main/resources/templates/menubar.html
@@ -1,13 +1,22 @@
 <div th:fragment="copy">
-<nav class="navbar fixed-top navbar-expand-lg navbar-light border-bottom pt-2 pb-2" th:fragment="copy">
+<nav class="navbar fixed-top navbar-expand-lg navbar-light border-bottom pt-2 pb-2" th:fragment="copy"
+     ng-controller="GeneralJsController">
     <div class="container">
         <a class="navbar-brand align-items-center" th:href="@{/}">
             <img class="img-fluid"
                  alt="UH Groupings Logo"
                  th:srcset="@{images/uh-groupings-logo.png 1x, images/uh-groupings-logo-2x.png 2x, images/uh-groupings-logo.svg}"
                  th:src="@{images/uh-groupings-logo.png}">
-            <span class="sr-only">UH Groupings</span>
-        </a>
+            <span class="sr-only">UH Groupings</span></a>
+        <span class="user-role rounded-circle seafoam-bg p-1 ml-5"
+              sec:authorize="hasAnyRole('ROLE_DEPARTMENT')"
+              tooltip data-placement="top"
+              th:title="#{screen.message.home.page.departmentAccount}">
+            <i class="fa fa-user p-2 position-relative" role="button" aria-label="Department Account Indicator"
+               th:attr="ng-click='displayDynamicModal(\'Warning\', \'' +
+                        #{screen.message.home.page.departmentAccount} + '\')'">
+                <i class="rounded-circle blue-bg text-light fa fa-school fa-xs p-1 position-absolute mt-2"></i>
+            </i></span>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Open the Navigation Menu">
             <span class="navbar-toggler-icon"></span>
@@ -37,7 +46,8 @@
                 </li>
                 <li class="nav-item" sec:authorize="!isAuthenticated()">
                     <div class="dropdown-divider d-block d-lg-none pb-3"></div>
-                    <a class="btn btn-primary btn-v-align login" th:href="@{/login}">Login <i class="fas fa-sign-in-alt" aria-hidden="false"></i></a>
+                    <a class="btn btn-primary btn-v-align login" th:href="@{/login}">Login
+                        <i class="fas fa-sign-in-alt" aria-hidden="false"></i></a>
                 </li>
                 <li class="nav-item" sec:authorize="isAuthenticated()">
                     <form action="/logout" th:action="@{/logout}" method="post">

--- a/src/test/java/edu/hawaii/its/groupings/access/AuthorizationServiceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/AuthorizationServiceTest.java
@@ -101,6 +101,11 @@ public class AuthorizationServiceTest {
         assertTrue(roleHolder.contains(Role.UH));
         assertTrue(roleHolder.contains(Role.OWNER));
         assertTrue(roleHolder.contains(Role.ADMIN));
+
+        // Reassign uhUuid value
+        uhUuid = "test";
+        roleHolder = authorizationService.fetchRoles(uhUuid, "test");
+        assertTrue(roleHolder.contains(Role.DEPARTMENT));
     }
 
     @Test
@@ -109,6 +114,7 @@ public class AuthorizationServiceTest {
         assertThat(roleHolder.size(), is(2));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
+        assertFalse(roleHolder.contains(Role.DEPARTMENT));
         assertFalse(roleHolder.contains(Role.OWNER));
         assertFalse(roleHolder.contains(Role.ADMIN));
 
@@ -116,13 +122,15 @@ public class AuthorizationServiceTest {
         assertThat(roleHolder.size(), is(1));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertFalse(roleHolder.contains(Role.UH));
+        assertFalse(roleHolder.contains(Role.DEPARTMENT));
         assertFalse(roleHolder.contains(Role.OWNER));
         assertFalse(roleHolder.contains(Role.ADMIN));
 
         roleHolder = authorizationService.fetchRoles("test", "test");
-        assertThat(roleHolder.size(), is(2));
+        assertThat(roleHolder.size(), is(3));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
+        assertTrue(roleHolder.contains(Role.DEPARTMENT));
         assertFalse(roleHolder.contains(Role.OWNER));
         assertFalse(roleHolder.contains(Role.ADMIN));
     }
@@ -134,6 +142,7 @@ public class AuthorizationServiceTest {
         assertThat(roleHolder.size(), is(4));
         assertTrue(roleHolder.contains(Role.ANONYMOUS)); // ???
         assertTrue(roleHolder.contains(Role.UH));
+        assertFalse(roleHolder.contains(Role.DEPARTMENT));
         assertTrue(roleHolder.contains(Role.EMPLOYEE));
         assertTrue(roleHolder.contains(Role.ADMIN));
 
@@ -141,6 +150,7 @@ public class AuthorizationServiceTest {
         assertThat(roleHolder.size(), is(3));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
+        assertFalse(roleHolder.contains(Role.DEPARTMENT));
         assertTrue(roleHolder.contains(Role.EMPLOYEE));
         assertFalse(roleHolder.contains(Role.ADMIN));
 
@@ -148,6 +158,7 @@ public class AuthorizationServiceTest {
         assertThat(roleHolder.size(), is(3));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
+        assertFalse(roleHolder.contains(Role.DEPARTMENT));
         assertTrue(roleHolder.contains(Role.EMPLOYEE));
         assertFalse(roleHolder.contains(Role.ADMIN));
 
@@ -156,6 +167,7 @@ public class AuthorizationServiceTest {
         assertThat(roleHolder.size(), is(2));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
+        assertFalse(roleHolder.contains(Role.DEPARTMENT));
         assertFalse(roleHolder.contains(Role.EMPLOYEE));
         assertFalse(roleHolder.contains(Role.ADMIN));
 
@@ -163,6 +175,7 @@ public class AuthorizationServiceTest {
         assertThat(roleHolder.size(), is(2));
         assertTrue(roleHolder.contains(Role.ANONYMOUS));
         assertTrue(roleHolder.contains(Role.UH));
+        assertFalse(roleHolder.contains(Role.DEPARTMENT));
         assertFalse(roleHolder.contains(Role.EMPLOYEE));
         assertFalse(roleHolder.contains(Role.ADMIN));
 


### PR DESCRIPTION
# Ticket Link

[Ticket 1494](https://uhawaii.atlassian.net/browse/GROUPINGS-1494)

# List of squashed commits

- Create the icon and place it in the nav bar
- Create hover message for the whole icon
- Place icon only in department accounts
- Make "login" section inside the borderline
- Move icon next to UH Groupings logo
- Add string literal dynamicModal
- Split the logo into another section
- Get rid of message string literal
- LightHouse Accessibility and SEO score fixes
- Move icon to the right
- Add Department role
- Add in Department role into test file
- Address GitHub comments about testing

# Test Checklist

- [X] Unit Tests Passed:
- [X] Jasmine Tests Passed:
- [X] General Visual Inspection:

