### PR TITLE
Handle empty string when updating grouping description

### DIFF
--- a/src/main/resources/static/javascript/mainApp/grouping.controller.js
+++ b/src/main/resources/static/javascript/mainApp/grouping.controller.js
@@ -357,7 +357,7 @@
             if ($scope.groupingDescription.localeCompare($scope.modelDescription) === 0) {
                 return $scope.cancelDescriptionEdit();
             }
-            $scope.groupingDescription = $scope.modelDescription;
+            $scope.groupingDescription = $scope.modelDescription.length > 0 ? $scope.modelDescription : $scope.noDescriptionMessage;
             groupingsService.updateDescription($scope.groupingDescription, $scope.selectedGrouping.path,
                 () => {
                     $scope.descriptionForm = !($scope.descriptionForm);

--- a/src/main/resources/templates/fragments/selected-grouping.html
+++ b/src/main/resources/templates/fragments/selected-grouping.html
@@ -89,7 +89,7 @@
                                            aria-label="Grouping Description"
                                            th:title="#{screen.message.admin.selectedGrouping.descriptionFormTitle}"
                                            th:placeholder="#{screen.message.admin.selectedGrouping.descriptionPlaceholder}"
-                                           ng-value="descriptionDisplay()"
+                                           ng-value="groupingDescription"
                                            ng-model="modelDescription"
                                            maxlength="{{ maxDescriptionLength }}"
                                            ng-trim="false"/>

--- a/src/test/javascript/grouping.controller.test.js
+++ b/src/test/javascript/grouping.controller.test.js
@@ -361,13 +361,23 @@ describe("GroupingController", () => {
         });
 
         beforeEach(() => {
-            scope.modelDescription = "descriptionOfAModal";
+            scope.groupingDescription = "description";
         });
 
-        it("should update the description for a grouping", () => {
+
+        it("should update the description with default value when new description is an empty string for a grouping", () => {
+            scope.modelDescription = "";
             spyOn(gs, "updateDescription").and.callThrough();
             scope.saveDescription();
-            expect(scope.modelDescription).toBe("descriptionOfAModal");
+            expect(scope.groupingDescription).toBe("No description given for this Grouping.");
+            expect(gs.updateDescription).toHaveBeenCalled();
+        });
+        
+        it("should update the description for a grouping", () => {
+            scope.modelDescription = "descriptionOfAModal";
+            spyOn(gs, "updateDescription").and.callThrough();
+            scope.saveDescription();
+            expect(scope.groupingDescription).toBe("descriptionOfAModal");
             expect(gs.updateDescription).toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
# Ticket Link

[1535](https://uhawaii.atlassian.net/browse/GROUPINGS-1535)

# List of squashed commits

- Handle empty string when updating grouping description

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:

