### PR TITLE
loadDataWithBodyRetry(): Set maxRetries to 3 and add incremental delay

### DIFF
--- a/src/main/resources/static/javascript/mainApp/app.service.js
+++ b/src/main/resources/static/javascript/mainApp/app.service.js
@@ -7,7 +7,7 @@
     UHGroupingsApp.factory("dataProvider", function ($http, $window, BASE_URL) {
 
         const timeLimit = 20000;
-        const maxRetries = 1;
+        const maxRetries = 3;
 
         /**
          * Sets delay in milliseconds. Used with await in async functions.
@@ -114,7 +114,7 @@
             },
 
             /**
-             * Perform a POST request to the specified URL that retries on error.
+             * Perform a POST request to the specified URL that retries on error with incremental delay.
              * @param {string} url - the URL to perform the request on
              * @param {any} data - the data to perform the request with
              * @param {function} callback - the function to perform on a successful request (200)
@@ -124,11 +124,12 @@
             loadDataWithBodyRetry(url, data, callback, callError, retries = maxRetries) {
                 $http.post(encodeURI(url), data)
                     .then((response) => callback(response.data))
-                    .catch((response) => {
+                    .catch(async (response) => {
                         if (retries <= 0) {
                             callError(response);
                             return;
                         }
+                        await delay(2000 * Math.log(maxRetries / retries));
                         this.loadDataWithBodyRetry(url, data, callback, callError, retries - 1);
                     });
             },


### PR DESCRIPTION
# Ticket Link

[GROUPINGS-1537](https://uhawaii.atlassian.net/browse/GROUPINGS-1537)

# Notes

- Used Math.log function so that the first retry has no delay (0 milliseconds)
  - log(maxRetries / retries) = 0 (Where maxRetries = 3 and retries = 3 on the first retry)
 - 2000 was picked to give a value of ~800 ms on second retry and ~2000 ms on the third

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:

