### PR TITLE
Implement default user login without CAS authentication

### DIFF
--- a/src/main/java/edu/hawaii/its/groupings/configuration/OotbCustomUserDetails.java
+++ b/src/main/java/edu/hawaii/its/groupings/configuration/OotbCustomUserDetails.java
@@ -1,0 +1,25 @@
+package edu.hawaii.its.groupings.configuration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import edu.hawaii.its.groupings.access.UhAttributes;
+import edu.hawaii.its.groupings.access.User;
+
+public class OotbCustomUserDetails extends User {
+
+    public OotbCustomUserDetails(String username, String password, Collection<GrantedAuthority> authorities,
+            String givenName, String cn, String email) {
+        super(username, password, authorities);
+        Map<String, Object> defaultAttributes = new HashMap<>();
+        defaultAttributes.put("cn", Arrays.asList(cn));
+        defaultAttributes.put("mail", Arrays.asList(email));
+        defaultAttributes.put("givenName", Arrays.asList(givenName));
+        this.setAttributes(new UhAttributes(defaultAttributes));
+    }
+
+}

--- a/src/main/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfig.java
+++ b/src/main/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfig.java
@@ -1,0 +1,110 @@
+package edu.hawaii.its.groupings.configuration;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.ws.config.annotation.DelegatingWsConfiguration;
+
+import edu.hawaii.its.groupings.access.DelegatingAuthenticationFailureHandler;
+
+@EnableWebSecurity
+@Configuration
+@ConditionalOnProperty(name = "grouping.api.server.type", havingValue = "OOTB")
+public class OotbSecurityConfig {
+
+    private static final Log logger = LogFactory.getLog(OotbSecurityConfig.class);
+
+    @Value("${grouping.api.server.type}")
+    private String serverType;
+
+    @Value("${ootb.default.user.name}")
+    private String name;
+
+    @Value("${ootb.default.user.username}")
+    private String username;
+
+    @Value("${ootb.default.user.authorities}")
+    private List<String> authorities;
+
+    @Value("${ootb.default.user.cn}")
+    private String cn;
+
+    @Value("${ootb.default.user.email}")
+    private String email;
+
+    @Value("${url.base}")
+    private String appUrlBase;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
+            throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public DelegatingAuthenticationFailureHandler authenticationFailureHandler() {
+        return new DelegatingAuthenticationFailureHandler(appUrlBase);
+    }
+
+    @Bean
+    public DelegatingWsConfiguration delegatingWsConfiguration() {
+        return new DelegatingWsConfiguration();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .addFilterBefore(ootbStaticUserAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests((auths)
+                        -> auths
+                        .requestMatchers(antMatcher("/")).permitAll()
+                        .requestMatchers(antMatcher("/announcements/**")).permitAll()
+                        .requestMatchers(antMatcher("/api/**")).hasRole("UH")
+                        .requestMatchers(antMatcher("/currentUser")).permitAll()
+                        .requestMatchers(antMatcher("/css/**")).permitAll()
+                        .requestMatchers(antMatcher("/fonts/**")).permitAll()
+                        .requestMatchers(antMatcher("/images/**")).permitAll()
+                        .requestMatchers(antMatcher("/javascript/**")).permitAll()
+                        .requestMatchers(antMatcher("/webjars/**")).permitAll()
+                        .requestMatchers(antMatcher("/home")).permitAll()
+                        .requestMatchers(antMatcher("/about")).permitAll()
+                        .requestMatchers(antMatcher("/feedback")).hasRole("UH")
+                        .requestMatchers(antMatcher("/denied")).permitAll()
+                        .requestMatchers(antMatcher("/404")).permitAll()
+                        .requestMatchers(antMatcher("/login")).hasRole("UH")
+                        .requestMatchers(antMatcher("/admin/**")).hasRole("ADMIN")
+                        .requestMatchers(antMatcher("/groupings/**")).hasAnyRole("ADMIN", "OWNER")
+                        .requestMatchers(antMatcher("/memberships/**")).hasRole("UH")
+                        .requestMatchers(antMatcher("/modal/apiError")).permitAll()
+                        .requestMatchers(antMatcher("/uhuuid-error")).permitAll()
+                        .requestMatchers(antMatcher("/error")).permitAll()
+                        .requestMatchers(antMatcher("/testing/**")).hasRole("ADMIN")
+                        .anyRequest().authenticated())
+                .csrf((csrf) -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .ignoringRequestMatchers(antMatcher("/api/**"), antMatcher("/logout")))
+                .httpBasic(withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public OotbStaticUserAuthenticationFilter ootbStaticUserAuthenticationFilter() {
+        return new OotbStaticUserAuthenticationFilter(serverType, name, username, cn, email, authorities);
+    }
+
+}

--- a/src/main/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilter.java
+++ b/src/main/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package edu.hawaii.its.groupings.configuration;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+public class OotbStaticUserAuthenticationFilter extends GenericFilterBean {
+    private final String serverType;
+    private final String name;
+    private final String username;
+    private final String cn;
+    private final String email;
+    private final List<String> authorities;
+
+    public OotbStaticUserAuthenticationFilter(String serverType, String name, String username, String cn, String email,
+            List<String> authorities) {
+        this.serverType = serverType;
+        this.name = name;
+        this.username = username;
+        this.authorities = authorities;
+        this.cn = cn;
+        this.email = email;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+        if (serverType.equals("OOTB") && SecurityContextHolder.getContext().getAuthentication() == null) {
+            OotbCustomUserDetails ootbCustomUserDetails = new OotbCustomUserDetails(
+                    username, "password",
+                    AuthorityUtils.createAuthorityList(authorities),
+                    name, cn, email);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    ootbCustomUserDetails, null, ootbCustomUserDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/resources/application-ootb.properties
+++ b/src/main/resources/application-ootb.properties
@@ -1,0 +1,19 @@
+# =========================================================================
+# Spring-related.
+spring.config.activate.on-profile=ootb
+spring.config.import=optional:file:${user.home}/.${user.name}-conf/uh-groupings-ui-overrides.properties
+app.api.handshake.enabled=false
+
+# There are two options: GROUPER, OOTB : "GROUPER" is a real grouper api service while "OOTB" is a ootb grouper api service.
+grouping.api.server.type=OOTB
+
+# OOTB default user information
+ootb.default.user.name=James
+ootb.default.user.username=defaultUser
+ootb.default.user.id=55555554
+ootb.default.user.authorities=ROLE_ADMIN,ROLE_UH,ROLE_OWNER
+ootb.default.user.cn=James
+ootb.default.user.email=example@hawaii.edu
+
+# =========================================================================
+app.environment=ootb

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,8 @@ cas.send.renew=false
 # =========================================================================
 # Grouper related.
 app.groupings.controller.uuid=1d7365a23c994f5f83f7b541d4a5fa5e
+# There are two options: GROUPER, OOTB : "GROUPER" is a real grouper api service while "OOTB" is a ootb grouper api service.
+grouping.api.server.type=GROUPER
 
 # These things can be removed
 # grouper REST URL

--- a/src/test/java/edu/hawaii/its/groupings/configuration/OotbCustomUserDetailsTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/OotbCustomUserDetailsTest.java
@@ -1,0 +1,50 @@
+package edu.hawaii.its.groupings.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import edu.hawaii.its.groupings.access.UhAttributes;
+
+@SpringBootTest(classes = { SpringBootWebApplication.class })
+public class OotbCustomUserDetailsTest {
+
+    @Test
+    public void testOotbCustomUserDetailsConstructor() {
+        Collection<GrantedAuthority> authorities = Arrays.asList(new SimpleGrantedAuthority("ROLE_USER"));
+        UhAttributes attributes = new UhAttributes(Map.of(
+                "cn", Arrays.asList("testiwa"),
+                "mail", Arrays.asList("testiwa@hawaii.edu"),
+                "givenName", Arrays.asList("John")
+        ));
+        OotbCustomUserDetails userDetails = new OotbCustomUserDetails(
+                "username", "password", authorities, "John", "testiwa", "testiwa@hawaii.edu");
+        userDetails.setAttributes(attributes);
+
+        assertNotNull(userDetails);
+        assertEquals("username", userDetails.getUsername());
+        assertEquals("password", userDetails.getUhUuid());
+        assertTrue(userDetails.getAuthorities().containsAll(authorities));
+        assertEquals("testiwa", userDetails.getAttributes().getValue("cn"));
+        assertEquals("testiwa@hawaii.edu", userDetails.getAttributes().getValue("mail"));
+        assertEquals("John", userDetails.getAttributes().getValue("givenName"));
+    }
+
+    @Test
+    public void testAttributesNotNull() {
+        Collection<GrantedAuthority> authorities = Arrays.asList(new SimpleGrantedAuthority("ROLE_USER"));
+        OotbCustomUserDetails userDetails = new OotbCustomUserDetails(
+                "username", "password", authorities, "John", "testiwa", "testiwa@hawaii.edu");
+
+        assertNotNull(userDetails.getAttributes());
+    }
+}

--- a/src/test/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfigTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfigTest.java
@@ -1,0 +1,23 @@
+package edu.hawaii.its.groupings.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = { SpringBootWebApplication.class })
+@ActiveProfiles("ootb")
+public class OotbSecurityConfigTest {
+
+    @Autowired
+    private OotbSecurityConfig ootbSecurityConfig;
+
+    @Test
+    public void construction() {
+        assertNotNull(ootbSecurityConfig);
+        assertNotNull(ootbSecurityConfig.ootbStaticUserAuthenticationFilter());
+    }
+
+}

--- a/src/test/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilterTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilterTest.java
@@ -1,0 +1,67 @@
+package edu.hawaii.its.groupings.configuration;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(classes = { SpringBootWebApplication.class })
+public class OotbStaticUserAuthenticationFilterTest {
+
+    @InjectMocks
+    private OotbStaticUserAuthenticationFilter filter;
+
+    @Mock
+    private ServletRequest request;
+
+    @Mock
+    private ServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @BeforeEach
+    public void setup() {
+        List<String> authorities = List.of("ROLE_USER");
+        filter = new OotbStaticUserAuthenticationFilter("OOTB", "John", "testiwa", "Smith", "testiwa@hawaii.edu",
+                authorities);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    public void testDoFilterWithOOTBServerTypeAndNoExistingAuth() throws IOException, ServletException {
+        when(securityContext.getAuthentication()).thenReturn(null);
+        filter.doFilter(request, response, chain);
+        verify(securityContext).setAuthentication(any());
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    public void testDoFilterWithOOTBServerTypeAndExistingAuth() throws IOException, ServletException {
+        when(securityContext.getAuthentication()).thenReturn(
+                mock(org.springframework.security.core.Authentication.class));
+        filter.doFilter(request, response, chain);
+        verify(securityContext, never()).setAuthentication(any());
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/src/test/java/edu/hawaii/its/groupings/configuration/SecurityConfigTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/SecurityConfigTest.java
@@ -1,12 +1,12 @@
 package edu.hawaii.its.groupings.configuration;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(classes = { SpringBootWebApplication.class })
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(classes = {SpringBootWebApplication.class})
 public class SecurityConfigTest {
 
     @Autowired


### PR DESCRIPTION
# Ticket Link

[Ticket-1670](https://uhawaii.atlassian.net/browse/GROUPINGS-1670)

# List of squashed commits

- Create ootb security config with custom filter chain

- Create authentication filter for bypass authentication that extends GerernicFilterBean and OotbCustomUserDetails for having ootb default suer information

- Add the logic to make OotbStaticUserAuthenticationFilter bean with the ootb default user properties from application-ootb and pass it through SecurityFilterChain


- Add ConditionalOnProperty grouping.api.server.type=GROUPER for security config

- Add and modify the ootb default user properties in application-ootb.properties, and manage the two types of API servers separately using two properties files

- Create the ootb security config test
- Fix codacy code style and environment of OotbSecurityConfigTest to skip the cas login related properties
- Add private to the field for ootb user properties and requestMatchers same as existed security config
- Fix codes with reviews
- Put all the ootb.default properties in a single class and modified all the related constructions
- Implement OotbCustomUserDetailsTest and OotbStaticUserAuthenticationFilterTest for checking security context and construction of OotbCustomUserDetails object
- Apply uh groupings code style
- Organize imports
- Fix mis typo

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:

