### PR TITLE
Refactoring the logic related to the button to update active user profiles in ootb

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/OotbRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/OotbRestController.java
@@ -13,12 +13,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -27,7 +25,6 @@ import edu.hawaii.its.groupings.access.User;
 import edu.hawaii.its.groupings.access.UserContextService;
 import edu.hawaii.its.groupings.configuration.OotbStaticUserAuthenticationFilter;
 import edu.hawaii.its.groupings.service.OotbActiveUserProfileService;
-import edu.hawaii.its.groupings.util.JsonUtil;
 
 @RestController
 @RequestMapping("/api/groupings/ootb")
@@ -60,6 +57,11 @@ public class OotbRestController {
      * the overrides file. Gets the active profiles and only runs the tests the
      * active profile relies on the API.
      */
+    @GetMapping("/availableProfiles")
+    public ResponseEntity<List<String>> getAvailableProfiles() {
+        List<String> profiles = ootbActiveUserProfileService.getAvailableProfiles();
+        return ResponseEntity.ok(profiles);
+    }
 
     @PostMapping(value = "/{activeProfile}")
     public ResponseEntity<String> updateActiveDefaultUser(@PathVariable String activeProfile) {

--- a/src/main/java/edu/hawaii/its/groupings/access/User.java
+++ b/src/main/java/edu/hawaii/its/groupings/access/User.java
@@ -1,9 +1,12 @@
 package edu.hawaii.its.groupings.access;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -12,6 +15,10 @@ public class User extends org.springframework.security.core.userdetails.User {
     public static final long serialVersionUID = 2L;
     private String uhUuid;
     private UhAttributes attributes;
+
+    public User(){
+        super("", "", null);
+    }
 
     public User(String uid, String uhUuid, Collection<GrantedAuthority> authorities) {
         super(uid, "", authorities);
@@ -22,7 +29,7 @@ public class User extends org.springframework.security.core.userdetails.User {
         super(uid, "", authorities);
     }
 
-    private User(Builder builder) {
+    public User(Builder builder) {
         super(builder.uid, "", builder.authorities);
         this.uhUuid = builder.uhUuid;
         this.attributes = new UhAttributes(builder.attributes);
@@ -74,7 +81,7 @@ public class User extends org.springframework.security.core.userdetails.User {
     public static class Builder {
         private final String uid;
         private String uhUuid;
-        private Collection<GrantedAuthority> authorities;
+        private final Collection<GrantedAuthority> authorities = new ArrayList<>();
         private final Map<String, Object> attributes = new HashMap<>();
 
         public Builder(String uid) {
@@ -86,8 +93,16 @@ public class User extends org.springframework.security.core.userdetails.User {
             return this;
         }
 
-        public Builder authorities(Collection<GrantedAuthority> authorities) {
-            this.authorities = authorities;
+        public Builder addAuthorities(String authority) {
+            this.authorities.add(new SimpleGrantedAuthority(authority));
+            return this;
+        }
+
+        public Builder addAuthorities(List<String> authorities) {
+             List<GrantedAuthority> grantedAuthorities = authorities.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+            this.authorities.addAll(grantedAuthorities);
             return this;
         }
 

--- a/src/main/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfig.java
+++ b/src/main/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfig.java
@@ -34,9 +34,10 @@ import edu.hawaii.its.groupings.service.OotbActiveUserProfileService;
 public class OotbSecurityConfig {
 
     private static final Log logger = LogFactory.getLog(OotbSecurityConfig.class);
-
-    @Value("${ootb.active.user.profile}")
     private String userProfile;
+
+    @Value("${ootb.profiles.filename}")
+    private String profilesFileName;
 
     @Value("${url.base}")
     private String appUrlBase;
@@ -108,6 +109,15 @@ public class OotbSecurityConfig {
 
     @Bean
     public UserDetailsService userDetailsService() {
-        return new OotbActiveUserProfileService();
+        // Make Profile Service with JSON file that user sets in the properties file
+        OotbActiveUserProfileService ootbActiveUserProfileService = new OotbActiveUserProfileService(profilesFileName);
+
+        // Set the default profile to admin
+        setUserProfile(ootbActiveUserProfileService.findGivenNameForAdminRole());
+        return ootbActiveUserProfileService;
+    }
+
+    public void setUserProfile(String userProfile) {
+        this.userProfile = userProfile;
     }
 }

--- a/src/main/java/edu/hawaii/its/groupings/configuration/Realm.java
+++ b/src/main/java/edu/hawaii/its/groupings/configuration/Realm.java
@@ -65,4 +65,6 @@ public class Realm {
         return isProfileActive("default");
     }
 
+    public boolean isOotb() { return isProfileActive("ootb"); }
+
 }

--- a/src/main/java/edu/hawaii/its/groupings/type/OotbActiveProfile.java
+++ b/src/main/java/edu/hawaii/its/groupings/type/OotbActiveProfile.java
@@ -1,0 +1,43 @@
+package edu.hawaii.its.groupings.type;
+
+import java.util.List;
+import java.util.Map;
+
+public class OotbActiveProfile {
+    private String uid;
+    private String uhUuid;
+    private List<String> authorities;
+    private Map<String, String> attributes;
+
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public String getUhUuid() {
+        return uhUuid;
+    }
+
+    public void setUhUuid(String uhUuid) {
+        this.uhUuid = uhUuid;
+    }
+
+    public List<String> getAuthorities() {
+        return authorities;
+    }
+
+    public void setAuthorities(List<String> authorities) {
+        this.authorities = authorities;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/src/main/java/edu/hawaii/its/groupings/util/JsonUtil.java
+++ b/src/main/java/edu/hawaii/its/groupings/util/JsonUtil.java
@@ -1,7 +1,12 @@
 package edu.hawaii.its.groupings.util;
 
+import java.nio.file.Files;
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -35,6 +40,28 @@ public class JsonUtil {
         return result;
     }
 
+    public static <T> List<T> asList(final String json, Class<T> type) {
+        List<T> result = null;
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            result = mapper.readValue(json, mapper.getTypeFactory().constructCollectionType(List.class, type));
+        } catch (Exception e) {
+            logger.error("Error: " + e);
+        }
+        return result;
+    }
+
+    public static String readJsonFileToString(String filePath) {
+        String result = null;
+        try {
+            Resource resource = new ClassPathResource(filePath);
+            result = Files.readString(resource.getFile().toPath());
+        } catch (Exception e) {
+            logger.error("Error: " + e);
+        }
+        return result;
+    }
+
     public static void printJson(Object obj) {
         ObjectMapper objectMapper = new ObjectMapper();
         try {
@@ -44,6 +71,7 @@ public class JsonUtil {
             logger.error("Error: " + e);
         }
     }
+
     public static void prettyPrint(Object object) {
         try {
             String json = new ObjectMapper()

--- a/src/main/resources/application-ootb.properties
+++ b/src/main/resources/application-ootb.properties
@@ -7,8 +7,8 @@ app.api.handshake.enabled=false
 # There are two options: GROUPER, OOTB : "GROUPER" is a real grouper api service while "OOTB" is a ootb grouper api service.
 grouping.api.server.type=OOTB
 
-# User Type : USER, OWNER, ADMIN
-ootb.active.user.profile=ADMIN
+# Profiles file
+ootb.profiles.filename=ootb.active.user.profiles.json
 
 # =========================================================================
 app.environment=ootb

--- a/src/main/resources/ootb.active.user.profiles.json
+++ b/src/main/resources/ootb.active.user.profiles.json
@@ -1,0 +1,32 @@
+[
+    {
+        "uid": "member0123",
+        "uhUuid": "11111111",
+        "authorities": ["ROLE_UH"],
+        "attributes": {
+            "cn": "MEMBER",
+            "mail": "member@hawaii.edu",
+            "givenName": "DefaultMember"
+        }
+    },
+    {
+        "uid": "owner0123",
+        "uhUuid": "22222222",
+        "authorities": ["ROLE_UH", "ROLE_OWNER"],
+        "attributes": {
+            "cn": "OWNER",
+            "mail": "owner@hawaii.edu",
+            "givenName": "OwnerUser"
+        }
+    },
+    {
+        "uid": "admin0123",
+        "uhUuid": "33333333",
+        "authorities": ["ROLE_ADMIN", "ROLE_UH", "ROLE_OWNER"],
+        "attributes": {
+            "cn": "ADMIN",
+            "mail": "admin@hawaii.edu",
+            "givenName": "AdminUser"
+        }
+    }
+]

--- a/src/main/resources/ootb.active.user.profiles2.json
+++ b/src/main/resources/ootb.active.user.profiles2.json
@@ -1,0 +1,32 @@
+{
+  "JAMES": {
+    "uid": "james0123",
+    "uhUuid": "11111111",
+    "authorities": ["ROLE_UH"],
+    "attributes": {
+      "cn": "MEMBER",
+      "mail": "member@hawaii.edu",
+      "givenName": "UH James"
+    }
+  },
+  "EDDY": {
+    "uid": "eddy0123",
+    "uhUuid": "22222222",
+    "authorities": ["ROLE_UH", "ROLE_OWNER"],
+    "attributes": {
+      "cn": "OWNER",
+      "mail": "owner@hawaii.edu",
+      "givenName": "Eddy Jeon"
+    }
+  },
+  "JSON": {
+    "uid": "json0123",
+    "uhUuid": "33333333",
+    "authorities": ["ROLE_ADMIN", "ROLE_UH", "ROLE_OWNER"],
+    "attributes": {
+      "cn": "ADMIN",
+      "mail": "json@hawaii.edu",
+      "givenName": "UH Json"
+    }
+  }
+}

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -28,6 +28,7 @@
         $scope.showGroupingPathColumn = JSON.parse(localStorage.getItem("showPathColumn") ?? false);
 
         $scope.ootbActiveUser = "";
+        $scope.availableProfiles = [];
 
         angular.extend(this, $controller("TableJsController", { $scope }));
 
@@ -266,6 +267,20 @@
          */
         $scope.hoverCopy = () => {
             $("[data-content='copy']").popover();
+        };
+
+        /**
+         * Get available ootb active profiles that defined in ootb.active.user.profiles.json
+         */
+        $scope.loadAvailableProfiles = () => {
+            groupingsService.getAvailableOotbActiveProfiles(
+                (data) => {
+                    $scope.availableProfiles = data;
+                },
+                (res) => {
+                    $scope.resStatus = res.status;
+                }
+            );
         };
 
         /**

--- a/src/main/resources/static/javascript/mainApp/groupings.service.js
+++ b/src/main/resources/static/javascript/mainApp/groupings.service.js
@@ -120,6 +120,14 @@
             },
 
             /**
+             * Get a list of available ootb active profiles.
+             */
+            getAvailableOotbActiveProfiles(onSuccess, onError) {
+                let endpoint = BASE_URL + "ootb/availableProfiles";
+                dataProvider.loadData(endpoint, onSuccess, onError);
+            },
+
+            /**
              * Update data harness bean with OotbActiveProfile
              * @param profile {String}
              * @param onSuccess {Function}

--- a/src/main/resources/templates/menubar.html
+++ b/src/main/resources/templates/menubar.html
@@ -50,7 +50,7 @@
                     <a class="btn btn-primary btn-v-align login" th:href="@{/login}">Login
                         <i class="fas fa-sign-in-alt" aria-hidden="false"></i></a>
                 </li>
-                <li class="nav-item" sec:authorize="isAuthenticated() and !hasAuthority('ROLE_OOTB')">
+                <li class="nav-item" sec:authorize="isAuthenticated()" th:if="${!@realm.isOotb()}">
                     <form action="/logout" th:action="@{/logout}" method="post">
                         <div class="dropdown-divider d-block d-lg-none pb-3"></div>
                         <button class="btn btn-outline-secondary btn-v-align text-nowrap" type="submit">Logout (<span
@@ -59,15 +59,14 @@
                         </button>
                     </form>
                 </li>
-                <li class="nav-item dropdown" sec:authorize="isAuthenticated() and hasAuthority('ROLE_OOTB')">
+                <li class="nav-item dropdown" sec:authorize="isAuthenticated()" th:if="${@realm.isOotb()}" ng-click="loadAvailableProfiles()">
                     <a class="btn btn-outline-secondary btn-v-align text-nowrap dropdown-toggle" href="#" id="navbarDropdownMenuLink2" role="button"
                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Logout (<span sec:authentication="name" id="name"></span>)
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                        <a class="dropdown-item" href="login" ng-click="updateActiveUserProfile('MEMBER')">Member</a>
-                        <a class="dropdown-item" href="login" ng-click="updateActiveUserProfile('OWNER')">Owner</a>
-                        <a class="dropdown-item" href="login" ng-click="updateActiveUserProfile('ADMIN')">Admin</a>
+                        <a class="dropdown-item" href="login" ng-repeat="profile in availableProfiles"
+                           ng-click="updateActiveUserProfile(profile)">{{profile}}</a>
                     </div>
                 </li>
             </ul>

--- a/src/test/java/edu/hawaii/its/api/controller/OotbRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/OotbRestControllerTest.java
@@ -6,47 +6,61 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
 
+import com.nimbusds.jose.shaded.gson.JsonIOException;
+
 import edu.hawaii.its.api.service.HttpRequestService;
+import edu.hawaii.its.groupings.access.User;
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
+import edu.hawaii.its.groupings.service.OotbActiveUserProfileService;
 
 @ActiveProfiles("ootb")
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class OotbRestControllerTest {
     private static final String REST_CONTROLLER_BASE = "/api/groupings/ootb";
 
-    private static final String ADMIN_UID = "admin0123";
+    private static final String ADMIN_GIVEN_NAME = "AdminUser";
 
-    @Autowired
-    GroupingsRestController groupingsRestController;
+    @MockBean
+    OotbRestController ootbRestController;
 
     @MockBean
     private HttpRequestService httpRequestService;
 
     @Autowired
     private WebApplicationContext context;
+
+    @MockBean
+    private OotbActiveUserProfileService ootbActiveUserProfileService;
 
     private MockMvc mockMvc;
 
@@ -58,19 +72,48 @@ public class OotbRestControllerTest {
 
         when(httpRequestService.makeApiRequestWithBody(anyString(), anyString(), anyList(), any(HttpMethod.class)))
                 .thenReturn(new ResponseEntity(HttpStatus.OK));
+        when(ootbActiveUserProfileService.findGivenNameForAdminRole()).thenReturn(ADMIN_GIVEN_NAME);
+    }
+
+    @Test
+    public void testGetAvailableProfiles() throws Exception {
+        String uri = REST_CONTROLLER_BASE + "/availableProfiles";
+        List<String> expectedProfiles = ootbActiveUserProfileService.getAvailableProfiles();
+        Map<String, User> orderedUsers = new LinkedHashMap<>();
+        expectedProfiles.forEach(profile -> orderedUsers.put(profile, mock(User.class)));
+
+        when(ootbActiveUserProfileService.getUsers()).thenReturn(orderedUsers);
+
+        ResultActions resultActions = mockMvc.perform(get(uri).contentType(MediaType.APPLICATION_JSON));
+
+        IntStream.range(0, expectedProfiles.size()).forEach(index -> {
+            try {
+                resultActions.andExpect(jsonPath("$[" + index + "]").value(expectedProfiles.get(index)));
+            } catch (Exception e) {
+                throw new JsonIOException(e);
+            }
+        });
+
+        verify(ootbRestController).getAvailableProfiles();
     }
 
     @Test
     public void updateActiveProfileTest() throws Exception {
-        String uri = REST_CONTROLLER_BASE + "/ADMIN";
-        given(httpRequestService.makeApiRequestWithBody(eq(ADMIN_UID), anyString(), anyList(), eq(HttpMethod.POST)))
-                .willReturn(new ResponseEntity(HttpStatus.OK));
+        Map<String, User> orderedUsers = new LinkedHashMap<>();
+        String adminGivenName = ootbActiveUserProfileService.findGivenNameForAdminRole();
+        orderedUsers.put(adminGivenName, mock(User.class));
+
+        String uri = REST_CONTROLLER_BASE + "/" + adminGivenName;
+
+        when(ootbActiveUserProfileService.getUsers()).thenReturn(orderedUsers);
+        given(httpRequestService.makeApiRequestWithBody(eq(ADMIN_GIVEN_NAME), anyString(), anyList(),
+                eq(HttpMethod.POST)))
+                .willReturn(new ResponseEntity<>(HttpStatus.OK));
 
         assertNotNull(mockMvc.perform(post(uri).with(csrf()))
                 .andExpect(status().isOk())
                 .andReturn());
 
-        verify(httpRequestService, times(1))
-                .makeApiRequestWithBody(eq(ADMIN_UID), anyString(), anyList(), eq(HttpMethod.POST));
+        verify(ootbRestController).updateActiveDefaultUser(ADMIN_GIVEN_NAME);
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/access/UserTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/access/UserTest.java
@@ -5,7 +5,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -61,5 +63,48 @@ public class UserTest {
         assertThat(user.getGivenName(), is("IamtstC"));
         assertThat(user.toString(), containsString("uid=a"));
         assertThat(user.toString(), containsString("uhUuid=null"));
+    }
+
+    @Test
+    public void testBuilderConstruction() {
+        // Create user with builder
+        User user = new User.Builder("testuid")
+                .uhUuid("1234")
+                .addAttribute("givenName", "IamtstC")
+                .addAttribute("cn", "IamtstC1")
+                .addAuthorities("ROLE_UH")
+                .addAuthorities(Arrays.asList("ROLE_ADMIN", "ROLE_OWNER"))
+                .build();
+
+        assertThat(user.getUid(), is("testuid"));
+        assertThat(user.getUhUuid(), is("1234"));
+        assertThat(user.getGivenName(), is("IamtstC"));
+        assertThat(user.getName(), is("IamtstC1"));
+
+        assertTrue(user.hasRole(Role.UH));
+        assertTrue(user.hasRole(Role.OWNER));
+        assertTrue(user.hasRole(Role.ADMIN));
+    }
+
+    @Test
+    public void testBuilderAttributes() {
+
+        User user = new User.Builder("anotheruid")
+                .addAttribute("cn", "IamtstC1")
+                .addAttribute("givenName", "IamtstC")
+                .build();
+
+        assertThat(user.getAttribute("cn"), is("IamtstC1"));
+        assertThat(user.getAttribute("givenName"), is("IamtstC"));
+    }
+
+    @Test
+    public void testBuilderAuthorities() {
+        User user = new User.Builder("authUser")
+                .addAuthorities(Arrays.asList("ROLE_UH", "ROLE_OWNER"))
+                .build();
+
+        assertTrue(user.hasRole(Role.UH));
+        assertTrue(user.hasRole(Role.OWNER));
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/configuration/RealmTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/RealmTest.java
@@ -20,6 +20,7 @@ public class RealmTest {
         assertTrue(realm.isDefault());
         assertFalse(realm.isTest());
         assertFalse(realm.isProduction());
+        assertFalse(realm.isOotb());
 
         assertFalse(realm.isProfileActive("not"));
         assertFalse(realm.isProfileActive(""));

--- a/src/test/java/edu/hawaii/its/groupings/service/OotbActiveUserProfileServiceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/service/OotbActiveUserProfileServiceTest.java
@@ -18,54 +18,30 @@ import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
 @ActiveProfiles("ootb")
 class OotbActiveUserProfileServiceTest {
 
-    private OotbActiveUserProfileService manager;
+    private OotbActiveUserProfileService ootbActiveUserProfileService;
 
     @BeforeEach
     public void setUp() {
-        manager = new OotbActiveUserProfileService();
-    }
-
-    @Test
-    public void testUserUserDetails() {
-        UserDetails userDetails = manager.loadUserByUsername("MEMBER");
-        assertNotNull(userDetails, "UserDetails should not be null");
-
-        User user = manager.getUsers().get("MEMBER");
-        assertNotNull(user, "Member should not be null");
-        assertEquals("member0123", user.getUid(), "Username should match");
-        assertEquals("11111111", user.getUhUuid(), "UhUuid should match");
-        assertEquals(2, user.getAuthorities().size(), "Should have 1 authority");
-    }
-
-    @Test
-    public void testOwnerUserDetails() {
-        UserDetails userDetails = manager.loadUserByUsername("OWNER");
-        assertNotNull(userDetails, "UserDetails should not be null");
-
-        User user = manager.getUsers().get("OWNER");
-        assertNotNull(user, "User should not be null");
-        assertEquals("owner0123", user.getUid(), "Username should match");
-        assertEquals("22222222", user.getUhUuid(), "UhUuid should match");
-        assertEquals(3, user.getAuthorities().size(), "Should have 2 authorities");
+        ootbActiveUserProfileService = new OotbActiveUserProfileService("ootb.active.user.profiles.json");
     }
 
     @Test
     public void testAdminUserDetails() {
-        UserDetails userDetails = manager.loadUserByUsername("ADMIN");
+        User user = ootbActiveUserProfileService.getUsers().get(ootbActiveUserProfileService.findGivenNameForAdminRole());
+        UserDetails userDetails = ootbActiveUserProfileService.loadUserByUsername(user.getGivenName());
         assertNotNull(userDetails, "UserDetails should not be null");
 
-        User user = manager.getUsers().get("ADMIN");
         assertNotNull(user, "User should not be null");
         assertEquals("admin0123", user.getUid(), "Username should match");
         assertEquals("33333333", user.getUhUuid(), "UhUuid should match");
-        assertEquals(4, user.getAuthorities().size(), "Should have 3 authorities");
+        assertEquals(3, user.getAuthorities().size(), "Should have 3 authorities");
     }
 
     @Test
     public void testLoadUserWithNonExistentUser() {
         // Test for non-existent user profile
         assertThrows(UsernameNotFoundException.class, () -> {
-            manager.loadUserByUsername("NON_EXISTENT");
+            ootbActiveUserProfileService.loadUserByUsername("NON_EXISTENT");
         }, "Expected UsernameNotFoundException for non-existent user profile");
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/type/OotbActiveProfileTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/type/OotbActiveProfileTest.java
@@ -1,0 +1,69 @@
+package edu.hawaii.its.groupings.type;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OotbActiveProfileTest {
+
+    private OotbActiveProfile profile;
+
+    @BeforeEach
+    public void setUp() {
+        profile = new OotbActiveProfile();
+    }
+
+    @Test
+    public void construction() {
+        assertNotNull(profile);
+    }
+
+    @Test
+    public void uid() {
+        assertNull(profile.getUid());
+        profile.setUid("123456");
+        assertThat(profile.getUid(), is("123456"));
+    }
+
+    @Test
+    public void uhUuid() {
+        assertNull(profile.getUhUuid());
+        profile.setUhUuid("ABCDEF");
+        assertThat(profile.getUhUuid(), is("ABCDEF"));
+    }
+
+    @Test
+    public void authorities() {
+        assertNull(profile.getAuthorities());
+        List<String> authorities = new ArrayList<>();
+        authorities.add("ADMIN");
+        authorities.add("USER");
+        profile.setAuthorities(authorities);
+        assertNotNull(profile.getAuthorities());
+        assertThat(profile.getAuthorities().size(), is(2));
+        assertThat(profile.getAuthorities().get(0), is("ADMIN"));
+        assertThat(profile.getAuthorities().get(1), is("USER"));
+    }
+
+    @Test
+    public void attributes() {
+        assertNull(profile.getAttributes());
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("key1", "value1");
+        attributes.put("key2", "value2");
+        profile.setAttributes(attributes);
+        assertNotNull(profile.getAttributes());
+        assertThat(profile.getAttributes().size(), is(2));
+        assertThat(profile.getAttributes().get("key1"), is("value1"));
+        assertThat(profile.getAttributes().get("key2"), is("value2"));
+    }
+}

--- a/src/test/java/edu/hawaii/its/groupings/util/JsonUtilTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/util/JsonUtilTest.java
@@ -1,12 +1,24 @@
 package edu.hawaii.its.groupings.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
 import edu.hawaii.its.groupings.type.Feedback;
 
@@ -42,5 +54,44 @@ public class JsonUtilTest {
     public void constructorIsPrivate() throws Exception {
         Constructor<JsonUtil> constructor = JsonUtil.class.getDeclaredConstructor();
         assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+    }
+    @Test
+    public void testAsList() {
+
+        Feedback fb1 = new Feedback();
+        fb1.setName("testiwa");
+        fb1.setEmail("testiwa@hawaii.edu");
+        fb1.setType("general");
+        fb1.setMessage("Hello World");
+        fb1.setExceptionMessage(null);
+
+        Feedback fb2 = new Feedback();
+        fb2.setName("testiwb");
+        fb2.setEmail("testiwb@hawaii.edu");
+        fb2.setType("support");
+        fb2.setMessage("Goodbye World");
+        fb2.setExceptionMessage(null);
+
+        String fb1Json = JsonUtil.asJson(fb1);
+        String fb2Json = JsonUtil.asJson(fb2);
+
+        String jsonArray = "[" + fb1Json + "," + fb2Json + "]";
+
+        List<Feedback> feedbackList = JsonUtil.asList(jsonArray, Feedback.class);
+
+        assertNotNull(feedbackList);
+        assertEquals(2, feedbackList.size());
+
+        Feedback retrievedFb1 = feedbackList.get(0);
+        assertEquals(fb1.getName(), retrievedFb1.getName());
+        assertEquals(fb1.getEmail(), retrievedFb1.getEmail());
+        assertEquals(fb1.getType(), retrievedFb1.getType());
+        assertEquals(fb1.getMessage(), retrievedFb1.getMessage());
+
+        Feedback retrievedFb2 = feedbackList.get(1);
+        assertEquals(fb2.getName(), retrievedFb2.getName());
+        assertEquals(fb2.getEmail(), retrievedFb2.getEmail());
+        assertEquals(fb2.getType(), retrievedFb2.getType());
+        assertEquals(fb2.getMessage(), retrievedFb2.getMessage());
     }
 }

--- a/src/test/javascript/general.controller.test.js
+++ b/src/test/javascript/general.controller.test.js
@@ -506,4 +506,38 @@ describe("GeneralController", () => {
         });
     });
 
+    describe('$scope.loadAvailableProfiles', () => {
+        let successResponse = [ "ADMIN", "OWNER", "MEMBER" ];
+        let errorResponse = { status: 404 };
+        beforeEach(() => {
+            spyOn(gs, "getAvailableOotbActiveProfiles").and.callFake((onSuccess, onError) => {
+                    onSuccess(successResponse);
+                    onError(errorResponse);
+            });
+            httpBackend.whenGET("currentUser").passThrough();
+        });
+
+        it('should load available profiles successfully', () => {
+            const expectedProfiles = [ "ADMIN", "OWNER", "MEMBER" ];
+            httpBackend.expectGET(BASE_URL + 'ootb/availableProfiles').respond(200, expectedProfiles);
+
+            spyOn(console, 'error');
+            scope.loadAvailableProfiles();
+
+            expect(scope.availableProfiles).toEqual(expectedProfiles);
+            expect(gs.getAvailableOotbActiveProfiles).toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
+        });
+
+        it('should handle errors when loading available profiles fails', () => {
+            const errorResponse = { status: 404, message: 'Not found' };
+            httpBackend.expectGET(BASE_URL + 'ootb/availableProfiles').respond(404, errorResponse);
+
+            spyOn(console, 'error');
+            scope.loadAvailableProfiles();
+
+            expect(scope.resStatus).toBe(errorResponse.status);
+        });
+    });
+
+
 });

--- a/src/test/javascript/groupings.service.test.js
+++ b/src/test/javascript/groupings.service.test.js
@@ -231,6 +231,20 @@ describe("GroupingsService", () => {
         });
     });
 
+    describe("getAvailableOotbActiveProfiles", () => {
+        it("should call dataProvider.loadData", () => {
+            spyOn(dp, "loadData");
+            gs.getAvailableOotbActiveProfiles(onSuccess, onError);
+            expect(dp.loadData).toHaveBeenCalled();
+        });
+
+        it("should use the correct path", () => {
+            gs.getAvailableOotbActiveProfiles(onSuccess, onError);
+            httpBackend.expectGET(BASE_URL + "ootb/availableProfiles").respond(200);
+            expect(httpBackend.flush).not.toThrow();
+        });
+    });
+
     describe("updateOotbActiveProfile", () => {
         let profile = "testProfile"; // Example profile for testing
 


### PR DESCRIPTION
# Ticket Link

[Ticket-1712](https://uhawaii.atlassian.net/browse/GROUPINGS-1712)

# List of squashed commits

- Implement loadAvailableProfiles in general.controller.js and getAvailableOotbActiveProfiles in groupingsService to call api in ui and store the available data in .availableProfiles

- Add ootb.active.user.profiles.json that contains multiple profiles information

- Apply ng-repeat with the values from scope.availableProfiles that contains the profiles from api call

- Add isOotb() function to check current spring boot active profile and apply to the menubar.html

- Add tests for loadAvailableProfiles and getAvailableOotbActiveProfiles in general.controller.test.js and groupings.service.test.js

- Enhance the Builder class functions in the User class (access folder)

- Refactor the file inputstream function in OotbActiveUserProfileService

- Implement getAvailableProfiles function test in the controller test, add @Mockbean OotbActiveUserProfileService and mock the map that contains the ootb active profiles

- Complete adding multiple ootb active profiles into the users map dynamically from json file with null safe and wrong path of file error
- Fix codacy code style
- Fix general controller test to check gs.getAvailableOotbActiveProfiles
- Modify the functions to initiate default active user by mapping JSON data to OotbActiveProfile with JsonUtil.asList() function
- Modify the end-point to get available profiles from OotbActiveUserProfileService
- Redesign the specification of JSON data for mapping to OotbActiveProfile
- Change the strategy to set property of Json file and the way to inject the file in the service layer
- Modify the tests for controller and service with dynamic active profile from JSON data
- Fix raw type of exception
- Implement the tests for ootb multiple active profiles in UserTest, RealmTest, JsonUtilTest, and OotbActiveProfileTest
# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:

