### PR TITLE
Improve ootb user experience and fix minor errors

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/OotbRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/OotbRestController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import edu.hawaii.its.api.service.HttpRequestService;
 import edu.hawaii.its.api.service.OotbHttpRequestService;
 import edu.hawaii.its.groupings.access.UserContextService;
 import edu.hawaii.its.groupings.configuration.OotbStaticUserAuthenticationFilter;
@@ -28,29 +27,24 @@ import edu.hawaii.its.groupings.type.OotbActiveProfile;
 @RequestMapping("/api/groupings/ootb")
 public class OotbRestController {
     private static final Log logger = LogFactory.getLog(OotbRestController.class);
-    private final PolicyFactory policy = Sanitizers.FORMATTING;;
+    private final PolicyFactory policy = Sanitizers.FORMATTING;
+    private final UserContextService userContextService;
+    private final OotbActiveUserProfileService ootbActiveUserProfileService;
+    private final OotbHttpRequestService ootbHttpRequestService;
+    private final OotbStaticUserAuthenticationFilter ootbAuthenticationFilter;
 
     @Value("${url.api.2.1.base}")
     private String API_2_1_BASE;
-
-    private final UserContextService userContextService;
-
-    private final OotbStaticUserAuthenticationFilter ootbAuthenticationFilter;
-
-    private final OotbActiveUserProfileService ootbActiveUserProfileService;
-
-    private final OotbHttpRequestService ootbHttpRequestService;
-
 
     // Constructor.
     public OotbRestController(UserContextService userContextService,
             OotbStaticUserAuthenticationFilter ootbAuthenticationFilter,
             OotbActiveUserProfileService ootbActiveUserProfileService,
-            OotbHttpRequestService ootbHttpRequestService) {
+            OotbHttpRequestService ootbHttpRequestService, OotbStaticUserAuthenticationFilter ootbAuthenticationFilter1) {
         this.userContextService = userContextService;
-        this.ootbAuthenticationFilter = ootbAuthenticationFilter;
         this.ootbActiveUserProfileService = ootbActiveUserProfileService;
         this.ootbHttpRequestService = ootbHttpRequestService;
+        this.ootbAuthenticationFilter = ootbAuthenticationFilter1;
     }
 
     /*
@@ -67,8 +61,8 @@ public class OotbRestController {
     @PostMapping(value = "/{activeProfile}")
     public ResponseEntity<OotbActiveProfile> updateActiveDefaultUser(@PathVariable String activeProfile) {
         String currentUid = policy.sanitize(userContextService.getCurrentUid());
-        ootbAuthenticationFilter.setUserProfile(activeProfile);
         OotbActiveProfile ootbActiveProfile = ootbActiveUserProfileService.getActiveProfiles().get(activeProfile);
+        ootbAuthenticationFilter.setUserProfile(activeProfile);
         String baseUri = API_2_1_BASE + "/activeProfile/ootb";
         return ootbHttpRequestService.makeApiRequestWithActiveProfileBody(currentUid, baseUri, ootbActiveProfile,
                 HttpMethod.POST);

--- a/src/main/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilter.java
+++ b/src/main/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilter.java
@@ -7,34 +7,44 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.filter.GenericFilterBean;
 
+import edu.hawaii.its.groupings.service.OotbActiveUserProfileService;
+
+@Service
+@Profile("ootb")
 public class OotbStaticUserAuthenticationFilter extends GenericFilterBean {
 
-    private final UserDetailsService userDetailsService;
-    private volatile String userProfile;
+    private final OotbActiveUserProfileService ootbActiveUserProfileService;
 
-    public OotbStaticUserAuthenticationFilter(UserDetailsService userDetailsService, String userProfile) {
-        this.userProfile = userProfile;
-        this.userDetailsService = userDetailsService;
+    private String currentUserProfile;
+
+    public OotbStaticUserAuthenticationFilter(
+            OotbActiveUserProfileService ootbActiveUserProfileService) {
+        this.ootbActiveUserProfileService = ootbActiveUserProfileService;
     }
 
     public void setUserProfile(String userProfile) {
-        this.userProfile = userProfile;
+        this.currentUserProfile = userProfile;
     }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
             throws IOException, ServletException {
         if (SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = userDetailsService.loadUserByUsername(userProfile);
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    userDetails, null, userDetails.getAuthorities());
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            UserDetails userDetails = ootbActiveUserProfileService.loadUserByUsername(
+                    currentUserProfile);
+            if(userDetails != null) {
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/edu/hawaii/its/groupings/configuration/SecurityConfig.java
+++ b/src/main/java/edu/hawaii/its/groupings/configuration/SecurityConfig.java
@@ -1,9 +1,9 @@
 package edu.hawaii.its.groupings.configuration;
 
-import edu.hawaii.its.groupings.access.CasUserDetailsServiceImpl;
-import edu.hawaii.its.groupings.access.DelegatingAuthenticationFailureHandler;
-import edu.hawaii.its.groupings.access.UserBuilder;
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
 import jakarta.annotation.PostConstruct;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apereo.cas.client.proxy.ProxyGrantingTicketStorage;
@@ -11,9 +11,9 @@ import org.apereo.cas.client.proxy.ProxyGrantingTicketStorageImpl;
 import org.apereo.cas.client.session.SingleSignOutFilter;
 import org.apereo.cas.client.validation.Saml11TicketValidator;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.cas.ServiceProperties;
 import org.springframework.security.cas.authentication.CasAssertionAuthenticationToken;
@@ -34,37 +34,31 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.util.Assert;
 import org.springframework.ws.config.annotation.DelegatingWsConfiguration;
 
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+import edu.hawaii.its.groupings.access.CasUserDetailsServiceImpl;
+import edu.hawaii.its.groupings.access.DelegatingAuthenticationFailureHandler;
+import edu.hawaii.its.groupings.access.UserBuilder;
 
 @EnableWebSecurity
 @Configuration
-@ConditionalOnProperty(name = "grouping.api.server.type", havingValue = "GROUPER", matchIfMissing = true)
+@Profile("!ootb")
 public class SecurityConfig {
 
     private static final Log logger = LogFactory.getLog(SecurityConfig.class);
-
+    private final UserBuilder userBuilder;
     @Value("${url.base}")
     private String appUrlBase;
-
     @Value("${app.url.home}")
     private String appUrlHome;
-
     @Value("${cas.login.url}")
     private String casLoginUrl;
-
     @Value("${cas.logout.url}")
     private String casLogoutUrl;
-
     @Value("${cas.main.url}")
     private String casMainUrl;
-
     @Value("${cas.saml.tolerance}")
     private long casSamlTolerance;
-
     @Value("${cas.send.renew:false}")
     private boolean casSendRenew;
-
-    private final UserBuilder userBuilder;
 
     public SecurityConfig(UserBuilder userBuilder) {
         this.userBuilder = userBuilder;

--- a/src/main/java/edu/hawaii/its/groupings/controller/HomeController.java
+++ b/src/main/java/edu/hawaii/its/groupings/controller/HomeController.java
@@ -1,5 +1,6 @@
 package edu.hawaii.its.groupings.controller;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 
@@ -9,6 +10,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import edu.hawaii.its.groupings.access.UserContextService;
+import edu.hawaii.its.groupings.configuration.Realm;
 import edu.hawaii.its.groupings.service.EmailService;
 import edu.hawaii.its.groupings.type.Feedback;
 
@@ -38,15 +41,21 @@ public class HomeController {
 
     private final UserContextService userContextService;
 
-    public HomeController(EmailService emailService, UserContextService userContextService) {
+    private final Realm realmService;
+
+    public HomeController(EmailService emailService, UserContextService userContextService, Realm realmService) {
         this.emailService = emailService;
         this.userContextService = userContextService;
+        this.realmService = realmService;
     }
 
     // Mapping to home.
     @GetMapping(value = { "/", "/home" })
     public String home(Map<String, Locale> locale) {
         logger.info("User at home. The client locale is " + locale);
+        if (realmService.isOotb()) {
+            return "redirect:/login";
+        }
         return "home";
     }
 

--- a/src/main/java/edu/hawaii/its/groupings/service/OotbActiveUserProfileService.java
+++ b/src/main/java/edu/hawaii/its/groupings/service/OotbActiveUserProfileService.java
@@ -6,6 +6,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -17,7 +21,11 @@ import edu.hawaii.its.groupings.type.OotbActiveProfile;
 import edu.hawaii.its.groupings.util.JsonUtil;
 
 @Service
+@Profile("ootb")
 public class OotbActiveUserProfileService implements UserDetailsService {
+
+    @Value("${ootb.profiles.filename}")
+    private String profilesFileName;
 
     // User is for SecurityContextHolder in AuthenticationFilter in UI project
     private final Map<String, User> users = new LinkedHashMap<>();
@@ -25,18 +33,12 @@ public class OotbActiveUserProfileService implements UserDetailsService {
     // OotbActiveProfile is for request body to make api request
     private final Map<String, OotbActiveProfile> activeProfiles = new LinkedHashMap<>();
 
-    // Default JSON file for active profiles
-    private String profilesFileName = "ootb.active.user.profiles.json";
-
-    public OotbActiveUserProfileService() {
-        initUsers();
-    }
+    public OotbActiveUserProfileService() {}
 
     public OotbActiveUserProfileService(String profilesFileName) {
         this.profilesFileName = profilesFileName;
-        initUsers();
     }
-
+    @PostConstruct
     private void initUsers() {
         List<OotbActiveProfile> ootbActiveProfiles =
                 JsonUtil.asList(JsonUtil.readJsonFileToString(profilesFileName), OotbActiveProfile.class);

--- a/src/main/resources/ootb.active.user.profiles.json
+++ b/src/main/resources/ootb.active.user.profiles.json
@@ -10,58 +10,48 @@
         },
         "groupings": [
             {
-                "name": "group1:include",
-                "displayName": "group1:include",
-                "extension": "include",
-                "displayExtension": "include",
-                "description": "This is the first group",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "group2:exclude",
-                "displayName": "group2:exclude",
+                "name": "admin-include:exclude",
+                "displayName": "admin-include:exclude",
                 "extension": "exclude",
                 "displayExtension": "exclude",
-                "description": "This is the second group",
+                "description": "Admin owned include group",
                 "members": [
                     {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
+                      "name": "MemberUser",
+                      "uid": "member0123",
+                      "uhUuid": "11111111"
                     }
                 ]
             },
             {
-                "name": "shared-groupPath:owners",
-                "displayName": "shared-groupPath:owners",
+                "name": "member-group:owners",
+                "displayName": "member-group:owners",
                 "extension": "owners",
                 "displayExtension": "owners",
-                "description": "This is the shared-groupPath",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
+                "description": "Member owned group",
+                "members": []
             },
             {
-                "name": "memberGroup:owners",
-                "displayName": "memberGroup:owners",
-                "extension": "owners",
-                "displayExtension": "owners",
-                "description": "This is the memberGroup",
+                "name": "member-group:include",
+                "displayName": "member-group:include",
+                "extension": "include",
+                "displayExtension": "include",
+                "description": "Member owned group",
                 "members": [
                     {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
+                        "name": "complex-member7",
+                        "uhUuid": "19283746",
+                        "uid": "cmember7"
+                    },
+                    {
+                        "name": "complex-member10",
+                        "uhUuid": "01234567",
+                        "uid": "cmember10"
+                    },
+                    {
+                      "name": "AdminUser",
+                      "uid": "admin0123",
+                      "uhUuid": "33333333"
                     }
                 ]
             }
@@ -78,86 +68,59 @@
         },
         "groupings": [
             {
-                "name": "group1:include",
-                "displayName": "group1:include",
+                  "name": "shared-group-in-each-profile:owners",
+                  "displayName": "shared-group-in-each-profile:owners",
+                  "extension": "owners",
+                  "displayExtension": "owners",
+                  "description": "This is a shared group in each profile",
+                  "members": [
+                      {
+                        "name": "shared-owner-2",
+                        "uhUuid": "29325231",
+                        "uid": "sowner2"
+                      }
+                  ]
+            },
+            {
+                "name": "admin-include:include",
+                "displayName": "admin-include:include",
                 "extension": "include",
                 "displayExtension": "include",
-                "description": "This is the first group",
+                "description": "Admin owned include group",
                 "members": [
                     {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
+                      "name": "OwnerUser",
+                      "uid": "owner0123",
+                      "uhUuid": "22222222"
+                    },
+                    {
+                      "name": "AdminUser",
+                      "uid": "admin0123",
+                      "uhUuid": "33333333"
                     }
                 ]
             },
-            {
-                "name": "group2:exclude",
-                "displayName": "group2:exclude",
+           {
+                "name": "owner-group:exclude",
+                "displayName": "owner-group:exclude",
                 "extension": "exclude",
                 "displayExtension": "exclude",
-                "description": "This is the second group",
+                "description": "Owner owned group",
                 "members": [
                     {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "shared-groupPath:owners",
-                "displayName": "shared-groupPath:owners",
-                "extension": "owners",
-                "displayExtension": "owners",
-                "description": "This is the shared-groupPath",
-                "members": [
+                        "name": "complex-member3",
+                        "uhUuid": "56473829",
+                        "uid": "cmember3"
+                    },
                     {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "shared-groupPath:include",
-                "displayName": "shared-groupPath:include",
-                "extension": "include",
-                "displayExtension": "include",
-                "description": "This is the shared-groupPath",
-                "members": [
+                        "name": "complex-member4",
+                        "uhUuid": "45261378",
+                        "uid": "cmember4"
+                    },
                     {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "ownerGroup:owners",
-                "displayName": "ownerGroup:owners",
-                "extension": "owners",
-                "displayExtension": "owners",
-                "description": "This is the fourth group",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "zoommeeting:owners",
-                "displayName": "zoommeeting:owners",
-                "extension": "owners",
-                "displayExtension": "owners",
-                "description": "This is the fourth group",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
+                      "name": "OwnerUser",
+                      "uid": "owner0123",
+                      "uhUuid": "22222222"
                     }
                 ]
             }
@@ -174,102 +137,31 @@
         },
         "groupings": [
             {
-                "name": "group1:include",
-                "displayName": "group1:include",
-                "extension": "include",
-                "displayExtension": "include",
-                "description": "This is the first group",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "group2:exclude",
-                "displayName": "group2:exclude",
-                "extension": "exclude",
-                "displayExtension": "exclude",
-                "description": "This is the second group",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "shared-groupPath:owners",
-                "displayName": "shared-groupPath:owners",
-                "extension": "owners",
-                "displayExtension": "owners",
-                "description": "This is the shared-groupPath",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    }
-                ]
-            },
-            {
-                "name": "adminGroup:owners",
-                "displayName": "adminGroup:owners",
-                "extension": "owners",
-                "displayExtension": "owners",
-                "description": "This is the fourth group",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    },
-                    {
-                      "name": "AdminUser",
-                      "uid": "admin0123",
-                      "uhUuid": "33333333"
-                    }
-                ]
-            },
-            {
-                "name": "adminGroup:include",
-                "displayName": "adminGroup:include",
-                "extension": "include",
-                "displayExtension": "include",
-                "description": "This is the fourth group",
-                "members": [
-                    {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
-                    },
-                    {
-                      "name": "AdminUser",
-                      "uid": "admin0123",
-                      "uhUuid": "33333333"
-                    },
-                    {
-                      "name": "OwnerUser",
-                      "uid": "owner0123",
-                      "uhUuid": "22222222"
-                    }
-                ]
-            },
-            {
-                "name": "adminGroup:basis",
-                "displayName": "adminGroup:basis",
+                "name": "shared-group-in-each-profile:basis",
+                "displayName": "shared-group-in-each-profile:basis",
                 "extension": "basis",
                 "displayExtension": "basis",
-                "description": "This is the fourth group",
+                "description": "This is a shared group in each profile",
                 "members": [
                     {
-                      "name": "s",
-                      "uhUuid": "11111112",
-                      "uid": "member2"
+                      "name": "shared-owner-3",
+                      "uhUuid": "29382734",
+                      "uid": "sowner3"
                     },
+                    {
+                      "name": "MemberUser",
+                      "uid": "member0123",
+                      "uhUuid": "11111111"
+                    }
+                ]
+            },
+            {
+                "name": "shared-group-in-groupings:owners",
+                "displayName": "shared-group-in-groupings:owners",
+                "extension": "owners",
+                "displayExtension": "owners",
+                "description": "This is a shared group in admin user groupings",
+                "members": [
                     {
                       "name": "AdminUser",
                       "uid": "admin0123",
@@ -279,6 +171,109 @@
                       "name": "OwnerUser",
                       "uid": "owner0123",
                       "uhUuid": "22222222"
+                    }
+                ]
+            },
+            {
+                "name": "shared-group-in-each-profile:owners",
+                "displayName": "shared-group-in-each-profile:owners",
+                "extension": "owners",
+                "displayExtension": "owners",
+                "description": "This is a shared group in each profile",
+                "members": [
+                    {
+                      "name": "shared-owner-3",
+                      "uhUuid": "29382734",
+                      "uid": "sowner3"
+                    }
+                ]
+            },
+            {
+                "name": "admin-include:owners",
+                "displayName": "admin-include:owners",
+                "extension": "owners",
+                "displayExtension": "owners",
+                "description": "Admin owned include group",
+                "members": []
+            },
+            {
+                "name": "admin-include:include",
+                "displayName": "admin-include:include",
+                "extension": "include",
+                "displayExtension": "include",
+                "description": "Admin owned include group",
+                "members": [
+                    {
+                      "name": "AdminUser",
+                      "uid": "admin0123",
+                      "uhUuid": "33333333"
+                    }
+                ]
+            },
+            {
+                "name": "admin-group:owners",
+                "displayName": "admin-group:owners",
+                "extension": "owners",
+                "displayExtension": "owners",
+                "description": "Admin owned group",
+                "members": []
+            },
+            {
+                "name": "owner-complex:owners",
+                "displayName": "Owner-Complex: Owners",
+                "extension": "owners",
+                "displayExtension": "Owners",
+                "description": "Owner's owned complex group",
+                "members": [
+                    {
+                        "name": "complex-member1",
+                        "uhUuid": "32532314",
+                        "uid": "cmember1"
+                    },
+                    {
+                        "name": "complex-member2",
+                        "uhUuid": "87453218",
+                        "uid": "cmember2"
+                    },
+                    {
+                        "name": "complex-member3",
+                        "uhUuid": "56473829",
+                        "uid": "cmember3"
+                    },
+                    {
+                        "name": "complex-member4",
+                        "uhUuid": "45261378",
+                        "uid": "cmember4"
+                    },
+                    {
+                        "name": "complex-member5",
+                        "uhUuid": "98765432",
+                        "uid": "cmember5"
+                    },
+                    {
+                        "name": "complex-member6",
+                        "uhUuid": "12345678",
+                        "uid": "cmember6"
+                    },
+                    {
+                        "name": "complex-member7",
+                        "uhUuid": "19283746",
+                        "uid": "cmember7"
+                    },
+                    {
+                        "name": "complex-member8",
+                        "uhUuid": "72635489",
+                        "uid": "cmember8"
+                    },
+                    {
+                        "name": "complex-member9",
+                        "uhUuid": "65432109",
+                        "uid": "cmember9"
+                    },
+                    {
+                        "name": "complex-member10",
+                        "uhUuid": "01234567",
+                        "uid": "cmember10"
                     }
                 ]
             }

--- a/src/test/java/edu/hawaii/its/api/controller/OotbRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/OotbRestControllerTest.java
@@ -1,121 +1,104 @@
 package edu.hawaii.its.api.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
 
-import com.nimbusds.jose.shaded.gson.JsonIOException;
-
-import edu.hawaii.its.api.service.HttpRequestService;
 import edu.hawaii.its.api.service.OotbHttpRequestService;
-import edu.hawaii.its.groupings.access.User;
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
+import edu.hawaii.its.groupings.controller.WithMockUhUser;
 import edu.hawaii.its.groupings.service.OotbActiveUserProfileService;
 import edu.hawaii.its.groupings.type.OotbActiveProfile;
 
-@ActiveProfiles("ootb")
 @SpringBootTest(classes = { SpringBootWebApplication.class })
+@ActiveProfiles("ootb")
 public class OotbRestControllerTest {
     private static final String REST_CONTROLLER_BASE = "/api/groupings/ootb";
 
-    private static final String ADMIN_GIVEN_NAME = "AdminUser";
+    private MockMvc mockMvc;
 
-    @MockBean
-    OotbRestController ootbRestController;
-
-    @MockBean
-    private OotbHttpRequestService ootbHttpRequestService;
+    @Autowired
+    private ApplicationContext applicationContext;
 
     @Autowired
     private WebApplicationContext context;
 
+    @Autowired
+    private OotbRestController ootbRestController;
+
     @MockBean
     private OotbActiveUserProfileService ootbActiveUserProfileService;
 
-    private MockMvc mockMvc;
+    @MockBean
+    private OotbHttpRequestService ootbHttpRequestService;
 
     @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(context)
                 .apply(springSecurity())
                 .build();
-
-        when(ootbHttpRequestService.makeApiRequestWithActiveProfileBody(anyString(), anyString(),
-                any(OotbActiveProfile.class), any(HttpMethod.class)))
-                .thenReturn(new ResponseEntity(HttpStatus.OK));
-        when(ootbActiveUserProfileService.findGivenNameForAdminRole()).thenReturn(ADMIN_GIVEN_NAME);
     }
 
     @Test
-    public void testGetAvailableProfiles() throws Exception {
+    @WithMockUhUser
+    public void getAvailableProfilesTest() throws Exception {
         String uri = REST_CONTROLLER_BASE + "/availableProfiles";
-        List<String> expectedProfiles = ootbActiveUserProfileService.getAvailableProfiles();
-        Map<String, User> orderedUsers = new LinkedHashMap<>();
+        List<String> expectedProfiles = List.of("Profile1", "Profile2");
+        Map<String, User> orderedUsers = new HashMap<>();
         expectedProfiles.forEach(profile -> orderedUsers.put(profile, mock(User.class)));
+        when(ootbActiveUserProfileService.getAvailableProfiles()).thenReturn(expectedProfiles);
 
-        when(ootbActiveUserProfileService.getUsers()).thenReturn(orderedUsers);
-
-        ResultActions resultActions = mockMvc.perform(get(uri).contentType(MediaType.APPLICATION_JSON));
-
-        IntStream.range(0, expectedProfiles.size()).forEach(index -> {
-            try {
-                resultActions.andExpect(jsonPath("$[" + index + "]").value(expectedProfiles.get(index)));
-            } catch (Exception e) {
-                throw new JsonIOException(e);
-            }
-        });
-
-        verify(ootbRestController).getAvailableProfiles();
+        assertNotNull(mockMvc.perform(get(uri).with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn());
     }
 
     @Test
-    public void testUpdateActiveDefaultUser() throws Exception {
-        // Given
-        String activeProfile = ADMIN_GIVEN_NAME;
+    @WithMockUhUser
+    public void updateActiveDefaultUserTest() throws Exception {
+        String activeProfile = "AdminUser";
         String uri = REST_CONTROLLER_BASE + "/" + activeProfile;
         String currentUserUid = "testUser";
         OotbActiveProfile profileData = new OotbActiveProfile();
 
         when(ootbActiveUserProfileService.getActiveProfiles()).thenReturn(Map.of(activeProfile, profileData));
-        when(ootbHttpRequestService.makeApiRequestWithActiveProfileBody(eq(currentUserUid), anyString(), eq(profileData),
-                eq(HttpMethod.POST)))
-                .thenReturn(new ResponseEntity<>(profileData, HttpStatus.OK));
 
         ResultActions result = mockMvc.perform(post(uri)
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON));
 
         result.andExpect(status().isOk());
-        verify(ootbRestController).updateActiveDefaultUser(activeProfile);
+        verify(ootbHttpRequestService, times(1))
+                .makeApiRequestWithActiveProfileBody(eq("user"), anyString(), eq(profileData), eq(HttpMethod.POST));
     }
 }

--- a/src/test/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfigTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/OotbSecurityConfigTest.java
@@ -1,15 +1,16 @@
 package edu.hawaii.its.groupings.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -18,35 +19,32 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 
+import edu.hawaii.its.api.controller.OotbRestController;
+import edu.hawaii.its.api.service.OotbHttpRequestService;
+import edu.hawaii.its.groupings.service.OotbActiveUserProfileService;
+
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 @ActiveProfiles("ootb")
-@ExtendWith(MockitoExtension.class)
 class OotbSecurityConfigTest {
 
     @Autowired
     private OotbSecurityConfig ootbSecurityConfig;
 
+    @MockBean
+    private OotbHttpRequestService ootbHttpRequestService;
     @Mock
     private AuthenticationConfiguration authenticationConfiguration;
 
-
-    @Test
-    public void testAuthenticationManager() throws Exception {
-        AuthenticationManager manager =
-                ootbSecurityConfig.authenticationManager(authenticationConfiguration, mock(UserDetailsService.class));
-        assertNotNull(manager, "Authentication Manager should not be null");
+    @BeforeEach
+    public void setUp() {
+         when(ootbHttpRequestService.makeApiRequestWithActiveProfileBody(any(),any(),any(),any()))
+        .thenReturn(null);
     }
 
     @Test
     public void testPasswordEncoder() {
         PasswordEncoder encoder = ootbSecurityConfig.passwordEncoder();
         assertNotNull(encoder, "Password Encoder should not be null");
-    }
-
-    @Test
-    public void testUserDetailsService() {
-        UserDetailsService userDetailsService = ootbSecurityConfig.userDetailsService();
-        assertNotNull(userDetailsService, "User Details Service should not be null");
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilterTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/configuration/OotbStaticUserAuthenticationFilterTest.java
@@ -15,9 +15,10 @@ import jakarta.servlet.ServletResponse;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,15 +26,23 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.ActiveProfiles;
 
+import edu.hawaii.its.api.service.OotbHttpRequestService;
+
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 @ActiveProfiles("ootb")
 public class OotbStaticUserAuthenticationFilterTest {
 
-    @InjectMocks
+    @Autowired
     private OotbStaticUserAuthenticationFilter filter;
+
+    @MockBean
+    private OotbHttpRequestService ootbHttpRequestService;
 
     @Mock
     private UserDetailsService userDetailsService;
+
+    @Mock
+    private UserDetails userDetails;
 
     @Mock
     private ServletRequest request;
@@ -47,14 +56,13 @@ public class OotbStaticUserAuthenticationFilterTest {
     @Mock
     private SecurityContext securityContext;
 
-    @Mock
-    private UserDetails userDetails;
-
     @BeforeEach
     public void setup() {
         SecurityContextHolder.setContext(securityContext);
         when(userDetailsService.loadUserByUsername("ADMIN")).thenReturn(userDetails);
-        filter = new OotbStaticUserAuthenticationFilter(userDetailsService, "ADMIN");
+
+        when(ootbHttpRequestService.makeApiRequestWithActiveProfileBody(any(), any(), any(), any()))
+                .thenReturn(null);
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/groupings/service/OotbActiveUserProfileServiceTest.java
+++ b/src/test/java/edu/hawaii/its/groupings/service/OotbActiveUserProfileServiceTest.java
@@ -5,29 +5,71 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.test.context.ActiveProfiles;
 
+import edu.hawaii.its.api.service.OotbHttpRequestService;
 import edu.hawaii.its.groupings.access.Role;
+import edu.hawaii.its.groupings.access.UhAttributes;
 import edu.hawaii.its.groupings.access.User;
 import edu.hawaii.its.groupings.configuration.SpringBootWebApplication;
+import edu.hawaii.its.groupings.type.OotbActiveProfile;
 
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 @ActiveProfiles("ootb")
 class OotbActiveUserProfileServiceTest {
 
+    @MockBean
     private OotbActiveUserProfileService ootbActiveUserProfileService;
+
+    @MockBean
+    private OotbHttpRequestService ootbHttpRequestService;
 
     @BeforeEach
     public void setUp() {
-        ootbActiveUserProfileService = new OotbActiveUserProfileService("ootb.active.user.profiles.json");
+
+        when(ootbHttpRequestService.makeApiRequestWithActiveProfileBody(any(), any(), any(), any()))
+                .thenReturn(null);
+
+        List<String> availableProfiles = List.of("admin0123");
+
+        UhAttributes mockAttributes = mock(UhAttributes.class);
+        when(mockAttributes.getValue("givenName")).thenReturn("admin0123");
+        when(mockAttributes.getValue("cn")).thenReturn("AdminUser");
+
+        User user = new User.Builder("admin0123")
+                .uhUuid("33333333")
+                .addAuthorities(List.of("ROLE_UH", "ROLE_OWNER", "ROLE_ADMIN"))
+                .addAttribute("givenName", "admin0123")
+                .build();
+
+        user.setAttributes(mockAttributes);
+
+        Map<String, OotbActiveProfile> activeProfiles = new HashMap<>();
+        OotbActiveProfile adminProfile = mock(OotbActiveProfile.class);
+        activeProfiles.put("admin0123", adminProfile);
+
+        when(ootbActiveUserProfileService.findGivenNameForAdminRole()).thenReturn("admin0123");
+        when(ootbActiveUserProfileService.loadUserByUsername("admin0123")).thenReturn(user);
+        when(ootbActiveUserProfileService.loadUserByUsername("NON_EXISTENT"))
+                .thenThrow(new UsernameNotFoundException("User not found"));
+        when(ootbActiveUserProfileService.getAvailableProfiles()).thenReturn(availableProfiles);
+        when(ootbActiveUserProfileService.getUsers()).thenReturn(Map.of("admin0123", user));
+        when(ootbActiveUserProfileService.getActiveProfiles()).thenReturn(activeProfiles);
     }
 
     @Test


### PR DESCRIPTION
# Ticket Link

[Ticket-1773](https://uhawaii.atlassian.net/browse/GROUPINGS-1773)

# List of squashed commits

- Add post construct on the OotbRestController to post update active profile with admin profiles
- Add the logic to redirect to the page to reload the page when user at home in ootb to avoid cache issue when changing active profiles
- Enhance the data for active user profiles in json file
- Modify all the ootb test class with mocking ootb controller to return null when it interacts with api projects in the class
- Change coverage yml with upload-artifact@v4
- Fix MockMVC to test end point for ootb rest controller
- Change dependency injections between ootb related classes by removing some beans and adding some annotations and local field in the class
- Modify the test for the changes in the class and add @ActiveProfiles annotation to separate the test from localhost env
- Fix codacy code style- 
- Add and Test various scenario with adding basis grouping member and add some logic to make difference when adding member between include and basis extension
- Add missed logic to set currentUser logged in into the userDetail in the ootbAuthenticationFilter when updateActiveDefaultUser end-point is executed


# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:

