### PR TITLE
Display modal to prevent dept accounts from being groupings owners

### DIFF
--- a/src/main/resources/static/javascript/mainApp/app.constants.js
+++ b/src/main/resources/static/javascript/mainApp/app.constants.js
@@ -24,6 +24,7 @@ UHGroupingsApp.constant("Message", {
         ADD_MEMBERS: "Add Members",
         REMOVE_MEMBER: "Remove Member",
         REMOVE_MEMBERS: "Remove Members",
+        OWNER_NOT_ADDED: "Owner Was Not Added",
         DISPLAY_OWNERS_ERROR: "Error Displaying Owners",
         INVALID_EMAIL_ERROR: "Invalid Email"
     },
@@ -36,6 +37,7 @@ UHGroupingsApp.constant("Message", {
         ADD_MEMBERS: { with: (listName) => `All members have been added successfully to the ${listName} list.` },
         REMOVE_MEMBER: { with: (member, listName) => `${member} has been successfully removed from the ${listName} list.` },
         REMOVE_MEMBERS: { with: (listName) => `All selected members have been successfully removed from the ${listName} list.` },
+        OWNER_NOT_ADDED: "Department accounts may not be assigned ownership due to accountability and lifecycle issues.  Please contact the IAM team, <its-iam-help@lists.hawaii.edu>, if there are any questions.",
         DISPLAY_OWNERS_ERROR: "There was an error displaying the owners.",
         INVALID_EMAIL_ERROR: "Please enter a valid email address."
     },

--- a/src/main/resources/templates/modal/addModal.html
+++ b/src/main/resources/templates/modal/addModal.html
@@ -58,8 +58,8 @@
             <th class="font-weight-normal modal-attributes">
                 {{ inInclude }}
                 <span class="fa fa-info-circle clickable" ng-if="inInclude === 'Yes'"
-                   tooltip
-                   th:title="#{screen.message.modal.add.tooltip.inInclude}" aria-hidden="true">
+                      tooltip
+                      th:title="#{screen.message.modal.add.tooltip.inInclude}" aria-hidden="true">
                 </span>
             </th>
         </tr>
@@ -68,8 +68,8 @@
             <th class="font-weight-normal modal-attributes">
                 {{ inExclude }}
                 <span class="fa fa-info-circle clickable" ng-if="inExclude === 'Yes'"
-                   tooltip
-                   th:title="#{screen.message.modal.add.tooltip.inExclude}" aria-hidden="true">
+                      tooltip
+                      th:title="#{screen.message.modal.add.tooltip.inExclude}" aria-hidden="true">
                 </span>
             </th>
         </tr>

--- a/src/test/javascript/grouping.controller.test.js
+++ b/src/test/javascript/grouping.controller.test.js
@@ -800,6 +800,8 @@ describe("GroupingController", () => {
         const invalid = { resultCode: "FAILURE", invalid: uhIdentifiers, results: [] };
 
         const member = ["testiwta"];
+        const memberDept = ["testiwt2"];
+        const membersDept = ["testiwta", "testiwt2"];
         const members = ["testiwta", "testiwtb"];
         const memberAttributeResultsSingle = {
             resultCode: "SUCCESS",
@@ -1021,7 +1023,7 @@ describe("GroupingController", () => {
                     }
                     scope.addMembers("Include", arr);
 
-                    httpBackend.expectPOST(BASE_URL + "members", arr).respond(200, []);
+                    httpBackend.expectPOST(BASE_URL + "members", arr).respond(200, results);
                     httpBackend.flush();
 
                     expect(scope.displayImportConfirmationModal).toHaveBeenCalled();
@@ -1040,6 +1042,28 @@ describe("GroupingController", () => {
                         uhIdentifiers: member,
                         listName: "Include"
                     });
+                });
+
+                it("should call $scope.displayDynamicModal() when trying to add a single dept account to Owners", () => {
+                    spyOn(scope, 'displayDynamicModal');
+                    scope.addMembers("owners", memberDept);
+
+                    const deptResults = { resultCode: "SUCCESS", invalid: [], results: ['testiwt2'] };
+                    httpBackend.expectPOST(BASE_URL + "members", ['testiwt2']).respond(200, deptResults);
+                    httpBackend.flush();
+
+                    expect(scope.displayDynamicModal).toHaveBeenCalled();
+                });
+
+                it("should call $scope.displayDynamicModal() when trying to add a dept account along with other members to Owners", () => {
+                    spyOn(scope, 'displayDynamicModal');
+                    scope.addMembers("owners", membersDept);
+
+                    const deptResults = { resultCode: "SUCCESS", invalid: [], results: [membersDept] };
+                    httpBackend.expectPOST(BASE_URL + "members", membersDept).respond(200, deptResults);
+                    httpBackend.flush();
+
+                    expect(scope.displayDynamicModal).toHaveBeenCalled();
                 });
             });
 


### PR DESCRIPTION
# Ticket Link

[Groupings-1772](https://uhawaii.atlassian.net/jira/software/c/projects/GROUPINGS/boards/18?assignee=712020%3Ad0e5c67f-f1f1-44a0-b5c9-282af528541e&selectedIssue=GROUPINGS-1772)

# List of squashed commits
- Removed commented out line
- Prevent dept accounts from being added as owners within addMembers
- Add new test for list adding owners and fix existing tests

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:

