### PR TITLE
Fix the Tooltip on Truncate for Grouping Path

### DIFF
--- a/src/main/resources/templates/fragments/groupings-list.html
+++ b/src/main/resources/templates/fragments/groupings-list.html
@@ -47,7 +47,7 @@
                     <form class="seamless border border-secondary rounded">
                         <input aria-label="Grouping Path" type="text"
                                class="text-truncate form-control form-control-sm border-0"
-                               tooltip-on-truncate="{{l.description}}" value={{l.path}} id={{l.path}}>
+                               tooltip-on-truncate="{{l.path}}" value={{l.path}} id={{l.path}}>
                         <div class="hover-text" data-toggle="popover" data-placement="top" data-trigger="hover" data-content="copy">
                             <div class="hover-text" data-toggle="popover" data-placement="top" data-trigger="click" data-content="copied!">
                                 <button class="btn btn-sm btn-clipboard" aria-label="Copy Path Button" tabindex="-1"


### PR DESCRIPTION
# Ticket Link

[Ticket 1805](https://uhawaii.atlassian.net/browse/GROUPINGS-1805)

# List of squashed commits

- Commit 1:Fix the Tooltip on Truncate for Grouping Path

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:

