### PR TITLE
 Implement support for service accounts

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -82,6 +82,7 @@ screen.message.modal.warning.directOwnerRemove=Cannot remove owner(s): at least 
 # Modal Add
 screen.message.modal.add.deptAccount=One or more departmental accounts are being added.
 screen.message.modal.add.deptAccount.admin=Departmental accounts cannot be assigned as admins.
+screen.message.modal.add.serviceAccount.admin=Service (machine) accounts cannot be assigned as admins.
 screen.message.modal.add.fail=There was an error adding:
 screen.message.modal.add.ensureValid=Please ensure that all entered UH members are valid and try again.
 screen.message.modal.add.empty=You must enter a UH member to add or remove.

--- a/src/main/resources/static/javascript/mainApp/admin.controller.js
+++ b/src/main/resources/static/javascript/mainApp/admin.controller.js
@@ -268,8 +268,8 @@
             }
 
             groupingsService.getMemberAttributeResults([sanitizedAdmin], (res) => {
-                // Prevent departmental accounts from being added as admins
-                $scope.isDeptAccount = $scope.checkForDeptAccount(res.results);
+                // Keep legacy admin restrictions: block uid===uhUuid or missing uhUuid.
+                $scope.isDeptAccount = $scope.checkForRestrictedAdminAccount(res.results);
                 if ($scope.isDeptAccount) {
                     $scope.containsDeptAcc = true;
                     return;

--- a/src/main/resources/static/javascript/mainApp/admin.controller.js
+++ b/src/main/resources/static/javascript/mainApp/admin.controller.js
@@ -268,9 +268,19 @@
             }
 
             groupingsService.getMemberAttributeResults([sanitizedAdmin], (res) => {
-                // Keep legacy admin restrictions: block uid===uhUuid or missing uhUuid.
-                $scope.isDeptAccount = $scope.checkForRestrictedAdminAccount(res.results);
-                if ($scope.isDeptAccount) {
+                const members = res.results ?? [];
+                $scope.containsDeptAcc = false;
+                $scope.containsServiceAccAdmin = false;
+
+                // Service accounts and department accounts are never eligible for admin assignment.
+                // Also treat leading "_" on the entered id as a service account: lookup may return empty or
+                // incomplete results, which would otherwise open the add modal with N/A fields.
+                const isServiceByEnteredId = _.isString(sanitizedAdmin) && sanitizedAdmin.startsWith("_");
+                if (isServiceByEnteredId || $scope.checkForServiceAccountMembers(members)) {
+                    $scope.containsServiceAccAdmin = true;
+                    return;
+                }
+                if ($scope.checkForDeptAccount(members)) {
                     $scope.containsDeptAcc = true;
                     return;
                 }

--- a/src/main/resources/static/javascript/mainApp/app.constants.js
+++ b/src/main/resources/static/javascript/mainApp/app.constants.js
@@ -46,6 +46,7 @@ UHGroupingsApp.constant("Message", {
         REMOVE_MEMBERS: { with: (listName) => `All selected members have been successfully removed from the ${listName} list.` },
         REMOVE_GROUP_PATH: { with: (groupingName, listName) => `${groupingName} has been successfully removed from the ${listName} list.`},
         OWNER_NOT_ADDED: "Department accounts may not be assigned ownership due to accountability and lifecycle issues.  Please contact the IAM team, <its-iam-help@lists.hawaii.edu>, if there are any questions.",
+        SERVICE_ACCOUNT_UHUUID_REQUIRED: "Service accounts can be assigned ownership only when a uhUuid is present. Please ensure the service account has a uhUuid assigned, then try again.",
         DISPLAY_OWNERS_ERROR: "There was an error displaying the owners.",
         INVALID_EMAIL_ERROR: "Please enter a valid email address.",
         INVALID_MULTI_ADD: "Only one owner-grouping can be added at a time.",

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -265,15 +265,66 @@
         };
 
         /**
-         * Checks if a member is a departmental account
-         * A departmental account is characterized by having the same uid as its uhUuid, or having a blank uhUuid
+         * Checks if member is service account using a machine identity uid with a leading underscore.
+         * @param {object} member - member object
+         * @returns {boolean}
+         */
+        $scope.isServiceAccount = (member) => {
+            const uid = member?.uid ?? "";
+            return uid.startsWith("_");
+        };
+
+        /**
+         * Checks whether  member has a non-empty uhUuid assigned.
+         * @param {object} member - member object
+         * @returns {boolean}
+         */
+        $scope.hasAssignedUhUuid = (member) => {
+            return !_.isEmpty(member?.uhUuid);
+        };
+
+        /**
+         * Checks if a member is a departmental account.
+         * Departmental accounts are non-service accounts whose uhUuid matches uid, or have no uhUuid.
+         * @param {object} member - member object
+         * @returns {boolean}
+         */
+        $scope.isDepartmentAccount = (member) => {
+            const uid = member?.uid ?? "";
+            const uhUuid = member?.uhUuid ?? "";
+            return !$scope.isServiceAccount(member) && (uid === uhUuid || _.isEmpty(uhUuid));
+        };
+
+        /**
+         * Checks if any members in the add list are departmental accounts.
          * @param {object[]} membersToAdd - members to add to a group or admin
-         * @returns {boolean} - True if a member is a departmental account
+         * @returns {boolean}
          */
         $scope.checkForDeptAccount = (membersToAdd) => {
-            return membersToAdd.some(member =>
-                member["uid"] === member['uhUuid'] || member['uhUuid'] === ""
-            );
+            return membersToAdd.some((member) => $scope.isDepartmentAccount(member));
+        };
+
+        /**
+         * Checks if any service accounts are missing a required uhUuid assignment.
+         * @param {object[]} membersToAdd - members to add to a group or admin
+         * @returns {boolean}
+         */
+        $scope.checkForServiceAccountWithoutUhUuid = (membersToAdd) => {
+            return membersToAdd.some((member) => $scope.isServiceAccount(member) && !$scope.hasAssignedUhUuid(member));
+        };
+
+        /**
+         * Checks if any members match restricted-admin rules.
+         * Admin add flow historically blocks accounts when uid matches uhUuid, or when uhUuid is blank.
+         * @param {object[]} membersToAdd - members to add as admins
+         * @returns {boolean}
+         */
+        $scope.checkForRestrictedAdminAccount = (membersToAdd) => {
+            return membersToAdd.some((member) => {
+                const uid = member?.uid ?? "";
+                const uhUuid = member?.uhUuid ?? "";
+                return uid === uhUuid || _.isEmpty(uhUuid);
+            });
         };
     }
 

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -144,6 +144,7 @@
             $scope.containsInput = false;
             $scope.invalidInput = false;
             $scope.containsDeptAcc = false;
+            $scope.containsServiceAccAdmin = false;
             $scope.addInputError = false;
             $scope.removeInputError = false;
         };
@@ -314,17 +315,12 @@
         };
 
         /**
-         * Checks if any members match restricted-admin rules.
-         * Admin add flow historically blocks accounts when uid matches uhUuid, or when uhUuid is blank.
-         * @param {object[]} membersToAdd - members to add as admins
+         * True if any member is a service account (machine identity uid with a leading underscore).
+         * @param {object[]} membersToAdd - members to evaluate
          * @returns {boolean}
          */
-        $scope.checkForRestrictedAdminAccount = (membersToAdd) => {
-            return membersToAdd.some((member) => {
-                const uid = member?.uid ?? "";
-                const uhUuid = member?.uhUuid ?? "";
-                return uid === uhUuid || _.isEmpty(uhUuid);
-            });
+        $scope.checkForServiceAccountMembers = (membersToAdd) => {
+            return membersToAdd.some((member) => $scope.isServiceAccount(member));
         };
     }
 

--- a/src/main/resources/static/javascript/mainApp/grouping.controller.js
+++ b/src/main/resources/static/javascript/mainApp/grouping.controller.js
@@ -926,15 +926,27 @@
                         return;
                     }
 
-                    // Prevent departmental accounts from being added as Owners
-                    $scope.hasDeptAccount = $scope.checkForDeptAccount(res.results);
-                    if (listName === "owners" && $scope.hasDeptAccount) {
-                        $scope.displayDynamicModal(
-                          Message.Title.OWNER_NOT_ADDED,
-                          Message.Body.OWNER_NOT_ADDED
-                        );
-                        $scope.isAddingMembers = false;
-                        return;
+                    if (listName === "owners") {
+                        // Department accounts are not eligible for owner assignments.
+                        $scope.hasDeptAccount = $scope.checkForDeptAccount(res.results);
+                        if ($scope.hasDeptAccount) {
+                            $scope.displayDynamicModal(
+                                Message.Title.OWNER_NOT_ADDED,
+                                Message.Body.OWNER_NOT_ADDED
+                            );
+                            $scope.isAddingMembers = false;
+                            return;
+                        }
+
+                        // Service accounts are allowed only if they have an assigned uhUuid.
+                        if ($scope.checkForServiceAccountWithoutUhUuid(res.results)) {
+                            $scope.displayDynamicModal(
+                                Message.Title.OWNER_NOT_ADDED,
+                                Message.Body.SERVICE_ACCOUNT_UHUUID_REQUIRED
+                            );
+                            $scope.isAddingMembers = false;
+                            return;
+                        }
                     }
 
                     // Display the appropriate modal

--- a/src/main/resources/templates/fragments/admin-error-messages.html
+++ b/src/main/resources/templates/fragments/admin-error-messages.html
@@ -20,6 +20,12 @@
              role="alert">
             <p th:text="#{screen.message.modal.add.preExisting.admin}"></p>
         </div>
+        <!--message for trying to add a service (machine) account as admin-->
+        <div ng-if="containsServiceAccAdmin"
+             class="float-md-left my-3 px-3 pt-2 rounded alert-danger show"
+             role="alert">
+            <p th:text="#{screen.message.modal.add.serviceAccount.admin}"></p>
+        </div>
         <!--message for trying to add a departmental account-->
         <div ng-if="containsDeptAcc"
              class="float-md-left my-3 px-3 pt-2 rounded alert-danger show"

--- a/src/test/javascript/admin.controller.test.js
+++ b/src/test/javascript/admin.controller.test.js
@@ -431,10 +431,6 @@ describe("AdminController", function () {
     });
 
     describe("addAdmin", () => {
-        const uhIdentifiers = ["testiwta"];
-        const results = { resultCode: "SUCCESS", invalid: [], results: [{ uid: "testiwta", uhUuid: "99997010" }] };
-        const invalid = { resultCode: "FAILURE", invalid: uhIdentifiers, results: [] };
-
         beforeEach(() => {
             expect(mockUserService.getCurrentUser).toHaveBeenCalled();
         });
@@ -458,6 +454,7 @@ describe("AdminController", function () {
 
         it("should check if the admin to add is a departmental account", () => {
             scope.containsDeptAcc = false;
+            scope.containsServiceAccAdmin = false;
             scope.adminToAdd = "testiwt2";
             scope.addAdmin();
 
@@ -471,10 +468,12 @@ describe("AdminController", function () {
 
             expect(scope.user).toBe(scope.adminToAdd);
             expect(scope.containsDeptAcc).toBeTrue();
+            expect(scope.containsServiceAccAdmin).toBeFalse();
         });
 
         it("should block service account admin when uhUuid is missing", () => {
             scope.containsDeptAcc = false;
+            scope.containsServiceAccAdmin = false;
             scope.adminToAdd = "_testiwt";
             scope.addAdmin();
 
@@ -486,12 +485,29 @@ describe("AdminController", function () {
             httpBackend.expectPOST(BASE_URL + "members", ["_testiwt"]).respond(200, serviceNoUhUuidResult);
             httpBackend.flush();
 
-            expect(scope.containsDeptAcc).toBeTrue();
+            expect(scope.containsServiceAccAdmin).toBeTrue();
+            expect(scope.containsDeptAcc).toBeFalse();
         });
 
-        it("should allow service account admin when uhUuid is assigned", () => {
+        it("should block service account admin when lookup returns no usable member row", () => {
             spyOn(scope, "displayAddModal");
             scope.containsDeptAcc = false;
+            scope.containsServiceAccAdmin = false;
+            scope.adminToAdd = "_testiwt";
+            scope.addAdmin();
+
+            const emptyResults = { resultCode: "SUCCESS", invalid: [], results: [] };
+            httpBackend.expectPOST(BASE_URL + "members", ["_testiwt"]).respond(200, emptyResults);
+            httpBackend.flush();
+
+            expect(scope.containsServiceAccAdmin).toBeTrue();
+            expect(scope.displayAddModal).not.toHaveBeenCalled();
+        });
+
+        it("should block service account admin even when uhUuid is assigned", () => {
+            spyOn(scope, "displayAddModal");
+            scope.containsDeptAcc = false;
+            scope.containsServiceAccAdmin = false;
             scope.adminToAdd = "_testiwt";
             scope.addAdmin();
 
@@ -503,8 +519,9 @@ describe("AdminController", function () {
             httpBackend.expectPOST(BASE_URL + "members", ["_testiwt"]).respond(200, serviceResult);
             httpBackend.flush();
 
+            expect(scope.containsServiceAccAdmin).toBeTrue();
             expect(scope.containsDeptAcc).toBeFalse();
-            expect(scope.displayAddModal).toHaveBeenCalled();
+            expect(scope.displayAddModal).not.toHaveBeenCalled();
         });
 
         it("should display the add modal", () => {

--- a/src/test/javascript/admin.controller.test.js
+++ b/src/test/javascript/admin.controller.test.js
@@ -432,7 +432,7 @@ describe("AdminController", function () {
 
     describe("addAdmin", () => {
         const uhIdentifiers = ["testiwta"];
-        const results = { resultCode: "SUCCESS", invalid: [], results: uhIdentifiers };
+        const results = { resultCode: "SUCCESS", invalid: [], results: [{ uid: "testiwta", uhUuid: "99997010" }] };
         const invalid = { resultCode: "FAILURE", invalid: uhIdentifiers, results: [] };
 
         beforeEach(() => {
@@ -461,11 +461,50 @@ describe("AdminController", function () {
             scope.adminToAdd = "testiwt2";
             scope.addAdmin();
 
-            httpBackend.expectPOST(BASE_URL + "members", ["testiwt2"]).respond(200, results);
+            const departmentResult = {
+                resultCode: "SUCCESS",
+                invalid: [],
+                results: [{ uid: "testiwt2", uhUuid: "testiwt2" }]
+            };
+            httpBackend.expectPOST(BASE_URL + "members", ["testiwt2"]).respond(200, departmentResult);
             httpBackend.flush();
 
             expect(scope.user).toBe(scope.adminToAdd);
             expect(scope.containsDeptAcc).toBeTrue();
+        });
+
+        it("should block service account admin when uhUuid is missing", () => {
+            scope.containsDeptAcc = false;
+            scope.adminToAdd = "_testiwt";
+            scope.addAdmin();
+
+            const serviceNoUhUuidResult = {
+                resultCode: "SUCCESS",
+                invalid: [],
+                results: [{ uid: "_testiwt", uhUuid: "" }]
+            };
+            httpBackend.expectPOST(BASE_URL + "members", ["_testiwt"]).respond(200, serviceNoUhUuidResult);
+            httpBackend.flush();
+
+            expect(scope.containsDeptAcc).toBeTrue();
+        });
+
+        it("should allow service account admin when uhUuid is assigned", () => {
+            spyOn(scope, "displayAddModal");
+            scope.containsDeptAcc = false;
+            scope.adminToAdd = "_testiwt";
+            scope.addAdmin();
+
+            const serviceResult = {
+                resultCode: "SUCCESS",
+                invalid: [],
+                results: [{ uid: "_testiwt", uhUuid: "12345678" }]
+            };
+            httpBackend.expectPOST(BASE_URL + "members", ["_testiwt"]).respond(200, serviceResult);
+            httpBackend.flush();
+
+            expect(scope.containsDeptAcc).toBeFalse();
+            expect(scope.displayAddModal).toHaveBeenCalled();
         });
 
         it("should display the add modal", () => {

--- a/src/test/javascript/general.controller.test.js
+++ b/src/test/javascript/general.controller.test.js
@@ -480,4 +480,30 @@ describe("GeneralController", () => {
         });
     });
 
+    describe("account type helper methods", () => {
+        it("should identify service accounts by leading underscore", () => {
+            expect(scope.isServiceAccount({ uid: "_testiwt", uhUuid: "12345678" })).toBeTrue();
+            expect(scope.isServiceAccount({ uid: "testiwta", uhUuid: "99997010" })).toBeFalse();
+        });
+
+        it("should identify department accounts and exclude service accounts", () => {
+            expect(scope.isDepartmentAccount({ uid: "testiwt2", uhUuid: "testiwt2" })).toBeTrue();
+            expect(scope.isDepartmentAccount({ uid: "_testiwt", uhUuid: "_testiwt" })).toBeFalse();
+        });
+
+        it("should detect service accounts without uhUuid", () => {
+            const membersToAdd = [
+                { uid: "testiwta", uhUuid: "99997010" },
+                { uid: "_testiwt", uhUuid: "" }
+            ];
+            expect(scope.checkForServiceAccountWithoutUhUuid(membersToAdd)).toBeTrue();
+        });
+
+        it("should keep admin restrictions for uid===uhUuid and empty uhUuid", () => {
+            expect(scope.checkForRestrictedAdminAccount([{ uid: "testiwt2", uhUuid: "testiwt2" }])).toBeTrue();
+            expect(scope.checkForRestrictedAdminAccount([{ uid: "_testiwt", uhUuid: "" }])).toBeTrue();
+            expect(scope.checkForRestrictedAdminAccount([{ uid: "testiwta", uhUuid: "99997010" }])).toBeFalse();
+        });
+    });
+
 });

--- a/src/test/javascript/general.controller.test.js
+++ b/src/test/javascript/general.controller.test.js
@@ -499,10 +499,9 @@ describe("GeneralController", () => {
             expect(scope.checkForServiceAccountWithoutUhUuid(membersToAdd)).toBeTrue();
         });
 
-        it("should keep admin restrictions for uid===uhUuid and empty uhUuid", () => {
-            expect(scope.checkForRestrictedAdminAccount([{ uid: "testiwt2", uhUuid: "testiwt2" }])).toBeTrue();
-            expect(scope.checkForRestrictedAdminAccount([{ uid: "_testiwt", uhUuid: "" }])).toBeTrue();
-            expect(scope.checkForRestrictedAdminAccount([{ uid: "testiwta", uhUuid: "99997010" }])).toBeFalse();
+        it("should detect any service account in a member list", () => {
+            expect(scope.checkForServiceAccountMembers([{ uid: "testiwta", uhUuid: "99997010" }])).toBeFalse();
+            expect(scope.checkForServiceAccountMembers([{ uid: "_testiwt", uhUuid: "12345678" }])).toBeTrue();
         });
     });
 

--- a/src/test/javascript/grouping.controller.test.js
+++ b/src/test/javascript/grouping.controller.test.js
@@ -1180,22 +1180,106 @@ describe("GroupingController", () => {
                     spyOn(scope, 'displayDynamicModal');
                     scope.addMembers("owners", memberDept);
 
-                    const deptResults = { resultCode: "SUCCESS", invalid: [], results: ['testiwt2'] };
-                    httpBackend.expectPOST(BASE_URL + "members", ['testiwt2']).respond(200, deptResults);
+                    const deptResults = {
+                        resultCode: "SUCCESS",
+                        invalid: [],
+                        results: [
+                            {
+                                name: "Testf-iwt-2 TestIAM-dept",
+                                uid: "testiwt2",
+                                uhUuid: "testiwt2"
+                            }
+                        ]
+                    };
+                    httpBackend.expectPOST(BASE_URL + "members", ["testiwt2"]).respond(200, deptResults);
                     httpBackend.flush();
 
-                    expect(scope.displayDynamicModal).toHaveBeenCalled();
+                    expect(scope.displayDynamicModal).toHaveBeenCalledWith(
+                        message.Title.OWNER_NOT_ADDED,
+                        message.Body.OWNER_NOT_ADDED
+                    );
                 });
 
                 it("should call $scope.displayDynamicModal() when trying to add a dept account along with other members to Owners", () => {
                     spyOn(scope, 'displayDynamicModal');
                     scope.addMembers("owners", membersDept);
 
-                    const deptResults = { resultCode: "SUCCESS", invalid: [], results: [membersDept] };
+                    const deptResults = {
+                        resultCode: "SUCCESS",
+                        invalid: [],
+                        results: [
+                            {
+                                name: "Testf-iwt-a TestIAM-staff",
+                                uid: "testiwta",
+                                uhUuid: "99997010"
+                            },
+                            {
+                                name: "Testf-iwt-2 TestIAM-dept",
+                                uid: "testiwt2",
+                                uhUuid: "testiwt2"
+                            }
+                        ]
+                    };
                     httpBackend.expectPOST(BASE_URL + "members", membersDept).respond(200, deptResults);
                     httpBackend.flush();
 
-                    expect(scope.displayDynamicModal).toHaveBeenCalled();
+                    expect(scope.displayDynamicModal).toHaveBeenCalledWith(
+                        message.Title.OWNER_NOT_ADDED,
+                        message.Body.OWNER_NOT_ADDED
+                    );
+                });
+
+                it("should allow adding a service account with assigned uhUuid to Owners", () => {
+                    spyOn(scope, "displayAddModal");
+                    spyOn(scope, "displayDynamicModal");
+                    const serviceAccount = ["_testiwt"];
+                    scope.addMembers("owners", serviceAccount);
+
+                    const serviceResults = {
+                        resultCode: "SUCCESS",
+                        invalid: [],
+                        results: [
+                            {
+                                name: "Groupings Service Account",
+                                uid: "_testiwt",
+                                uhUuid: "12345678"
+                            }
+                        ]
+                    };
+                    httpBackend.expectPOST(BASE_URL + "members", serviceAccount).respond(200, serviceResults);
+                    httpBackend.flush();
+
+                    expect(scope.displayDynamicModal).not.toHaveBeenCalled();
+                    expect(scope.displayAddModal).toHaveBeenCalledWith({
+                        membersAttributes: serviceResults,
+                        uhIdentifiers: serviceAccount,
+                        listName: "owners"
+                    });
+                });
+
+                it("should block adding a service account without uhUuid to Owners", () => {
+                    spyOn(scope, "displayDynamicModal");
+                    const serviceAccountNoUhUuid = ["_testiwt"];
+                    scope.addMembers("owners", serviceAccountNoUhUuid);
+
+                    const serviceResults = {
+                        resultCode: "SUCCESS",
+                        invalid: [],
+                        results: [
+                            {
+                                name: "Service Account Without UHUUID",
+                                uid: "_testiwt",
+                                uhUuid: ""
+                            }
+                        ]
+                    };
+                    httpBackend.expectPOST(BASE_URL + "members", serviceAccountNoUhUuid).respond(200, serviceResults);
+                    httpBackend.flush();
+
+                    expect(scope.displayDynamicModal).toHaveBeenCalledWith(
+                        message.Title.OWNER_NOT_ADDED,
+                        message.Body.SERVICE_ACCOUNT_UHUUID_REQUIRED
+                    );
                 });
             });
 


### PR DESCRIPTION
# Ticket Link

[2174](https://uhawaii.atlassian.net/browse/GROUPINGS-2174)

# List of squashed commits

- Add support for service account owners
- Add unit tests for service account owners
- Harden admin rules for service/dept accounts and fix empty-lookup modal

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
- [ ] Checked For ADA Compliance:
