### PR TITLE
Update sync destination tooltip not based on JSON value specified

### DIFF
--- a/src/main/resources/static/javascript/mainApp/grouping.controller.js
+++ b/src/main/resources/static/javascript/mainApp/grouping.controller.js
@@ -358,6 +358,12 @@
         $scope.getGroupingSyncDest = (groupPath) => {
             return new Promise((resolve) => groupingsService.getGroupingSyncDest(groupPath, (res) => {
                 $scope.syncDestArray = res.syncDestinations;
+                // Trim tooltip text to remove LISTSERV-specific details
+                $scope.syncDestArray.forEach(syncDest => {
+                    if (syncDest.tooltip && syncDest.tooltip.includes("On lists set to Send=Editor")) {
+                        syncDest.tooltip = syncDest.tooltip.split("On lists set to Send=Editor")[0].trim();
+                    }
+                });
                 resolve();
                 $scope.initSyncStatuses();
             }, (res) => {

--- a/src/main/resources/templates/fragments/sync-destinations.html
+++ b/src/main/resources/templates/fragments/sync-destinations.html
@@ -22,6 +22,7 @@
                             </label>
                             <span class="fa fa-question-circle" role="button"
                                   tooltip="{{syncDest.tooltip}}" data-placement="right"
+                                  aria-label="{{syncDest.tooltip}}"
                                   tabindex="0"
                                   th:attr="ng-click='displayDynamicModal(\'Sync Destinations Information\', ' + 'syncDest.tooltip)',
                                   ng-keypress='$event.keyCode === 13 ? displayDynamicModal(\'Sync Destinations ' +    'Information\', syncDest.tooltip) : null'">

--- a/src/main/resources/templates/fragments/sync-destinations.html
+++ b/src/main/resources/templates/fragments/sync-destinations.html
@@ -21,10 +21,10 @@
                                 {{ syncDest.description }}
                             </label>
                             <span class="fa fa-question-circle" role="button"
-                                  title="This option syncs destinations to {{ syncDest.description }}"
                                   tooltip="{{syncDest.tooltip}}" data-placement="right"
                                   tabindex="0"
-                                  th:attr="ng-click='displayDynamicModal(\'Sync Destinations Information\', ' + 'syncDest.tooltip)', ng-keypress='$event.keyCode === 13 ? displayDynamicModal(\'Sync Destinations ' +    'Information\', syncDest.tooltip) : null'">
+                                  th:attr="ng-click='displayDynamicModal(\'Sync Destinations Information\', ' + 'syncDest.tooltip)',
+                                  ng-keypress='$event.keyCode === 13 ? displayDynamicModal(\'Sync Destinations ' +    'Information\', syncDest.tooltip) : null'">
                             </span>
                         </div>
                     </div>

--- a/src/test/javascript/grouping.controller.test.js
+++ b/src/test/javascript/grouping.controller.test.js
@@ -2824,57 +2824,23 @@ describe("GroupingController", () => {
             });
         });
 
-        it("should populate syncDestArray with sync destinations", (done) => {
+        it("should populate syncDestArray and trim tooltips containing 'On lists set to Send=Editor'", (done) => {
+            spyOn(scope, "initSyncStatuses").and.callThrough();
             scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // Verify array population
                 expect(scope.syncDestArray.length).toBe(3);
                 expect(scope.syncDestArray[0].name).toBe("google-sync");
                 expect(scope.syncDestArray[1].name).toBe("listserv-sync");
-                done();
-            });
-            scope.$apply();
-        });
 
-        it("should trim tooltips containing 'On lists set to Send=Editor'", (done) => {
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                // First tooltip should be trimmed
+                // Verify tooltip trimming for items with "On lists set to Send=Editor"
                 expect(scope.syncDestArray[0].tooltip).toBe("Synchronize with Google Groups.");
-                // Second tooltip should also be trimmed
                 expect(scope.syncDestArray[1].tooltip).toBe("Synchronize with LISTSERV.");
-                done();
-            });
-            scope.$apply();
-        });
 
-        it("should not modify tooltips without 'On lists set to Send=Editor'", (done) => {
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // Verify tooltips without the phrase are not modified
                 expect(scope.syncDestArray[2].tooltip).toBe("This tooltip does not have the LISTSERV text");
-                done();
-            });
-            scope.$apply();
-        });
 
-        it("should call gs.getGroupingSyncDest with correct parameters", (done) => {
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                expect(gs.getGroupingSyncDest).toHaveBeenCalledWith(mockGroupPath, jasmine.any(Function), jasmine.any(Function));
-                done();
-            });
-            scope.$apply();
-        });
-
-        it("should call initSyncStatuses after populating syncDestArray", (done) => {
-            spyOn(scope, "initSyncStatuses").and.callThrough();
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // Verify side effects
                 expect(scope.initSyncStatuses).toHaveBeenCalled();
-                done();
-            });
-            scope.$apply();
-        });
-
-        it("should handle tooltip with multiple occurrences of 'On lists set to Send=Editor'", (done) => {
-            mockSyncDestinations[0].tooltip = "First part. On lists set to Send=Editor, text1. On lists set to Send=Editor, text2";
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                // Should only trim the first occurrence and everything after it
-                expect(scope.syncDestArray[0].tooltip).toBe("First part.");
                 done();
             });
             scope.$apply();
@@ -2886,113 +2852,6 @@ describe("GroupingController", () => {
             });
             scope.getGroupingSyncDest(mockGroupPath).then(() => {
                 expect(scope.syncDestArray.length).toBe(0);
-                done();
-            });
-            scope.$apply();
-        });
-
-        it("should trim whitespace after splitting tooltip", (done) => {
-            mockSyncDestinations[0].tooltip = "Description.   On lists set to Send=Editor, more text";
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                // Should trim whitespace after split
-                expect(scope.syncDestArray[0].tooltip).toBe("Description.");
-                done();
-            });
-            scope.$apply();
-        });
-    });
-
-    describe("Sync Destination Tooltip Modal Display", () => {
-        let mockGroupPath;
-        let mockSyncDestinations;
-
-        beforeEach(() => {
-            mockGroupPath = "test-grouping-path";
-            mockSyncDestinations = [
-                {
-                    description: "Google-Group: #uh-iam-group",
-                    hidden: false,
-                    name: "google-sync",
-                    synced: false,
-                    tooltip: "Synchronize with Google Groups. On lists set to Send=Editor, editors are allowed to post directly to the list without moderation/approval."
-                },
-                {
-                    description: "LISTSERV List: #uh-listserv",
-                    hidden: false,
-                    name: "listserv-sync",
-                    synced: true,
-                    tooltip: "Synchronize with LISTSERV. On lists set to Send=Editor, editors are allowed to post directly to the list without moderation/approval."
-                }
-            ];
-            spyOn(gs, "getGroupingSyncDest").and.callFake((path, onSuccess, onError) => {
-                onSuccess({ syncDestinations: mockSyncDestinations });
-            });
-            spyOn(scope, "displayDynamicModal");
-        });
-
-        it("should display trimmed tooltip when user clicks question mark icon", (done) => {
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                // Simulate user clicking the question mark icon for the first sync destination
-                const trimmedTooltip = scope.syncDestArray[0].tooltip;
-
-                // Call displayDynamicModal as the UI would
-                scope.displayDynamicModal("Sync Destinations Information", trimmedTooltip);
-
-                // Verify the trimmed tooltip (without LISTSERV text) was passed to the modal
-                expect(scope.displayDynamicModal).toHaveBeenCalledWith(
-                    "Sync Destinations Information",
-                    "Synchronize with Google Groups."
-                );
-                done();
-            });
-            scope.$apply();
-        });
-
-        it("should not include 'On lists set to Send=Editor' text in modal display", (done) => {
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                const firstSyncDestTooltip = scope.syncDestArray[0].tooltip;
-
-                // Verify the LISTSERV text is not in the tooltip
-                expect(firstSyncDestTooltip).not.toContain("On lists set to Send=Editor");
-                expect(firstSyncDestTooltip).not.toContain("editors are allowed to post");
-
-                done();
-            });
-            scope.$apply();
-        });
-
-        it("should display all sync destinations with trimmed tooltips", (done) => {
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                // Verify all sync destinations have trimmed tooltips
-                scope.syncDestArray.forEach(syncDest => {
-                    if (syncDest.tooltip && syncDest.tooltip.includes("Synchronize")) {
-                        expect(syncDest.tooltip).not.toContain("On lists set to Send=Editor");
-                    }
-                });
-                done();
-            });
-            scope.$apply();
-        });
-
-        it("should preserve non-LISTSERV tooltip text for display", (done) => {
-            // Add a sync destination without LISTSERV text
-            mockSyncDestinations.push({
-                description: "Custom Sync",
-                hidden: false,
-                name: "custom-sync",
-                synced: false,
-                tooltip: "Custom sync destination tooltip"
-            });
-
-            scope.getGroupingSyncDest(mockGroupPath).then(() => {
-                const customSyncTooltip = scope.syncDestArray[2].tooltip;
-                expect(customSyncTooltip).toBe("Custom sync destination tooltip");
-                scope.displayDynamicModal("Sync Destinations Information", customSyncTooltip);
-
-                expect(scope.displayDynamicModal).toHaveBeenCalledWith(
-                    "Sync Destinations Information",
-                    "Custom sync destination tooltip"
-                );
                 done();
             });
             scope.$apply();

--- a/src/test/javascript/grouping.controller.test.js
+++ b/src/test/javascript/grouping.controller.test.js
@@ -2790,6 +2790,215 @@ describe("GroupingController", () => {
         });
     });
 
+    describe("getGroupingSyncDest", () => {
+        let mockGroupPath;
+        let mockSyncDestinations;
+
+        beforeEach(() => {
+            mockGroupPath = "test-grouping-path";
+            mockSyncDestinations = [
+                {
+                    description: "Google-Group: #uh-iam-group",
+                    hidden: false,
+                    name: "google-sync",
+                    synced: false,
+                    tooltip: "Synchronize with Google Groups. On lists set to Send=Editor, editors are allowed to post directly to the list without moderation/approval."
+                },
+                {
+                    description: "LISTSERV List: #uh-listserv",
+                    hidden: false,
+                    name: "listserv-sync",
+                    synced: true,
+                    tooltip: "Synchronize with LISTSERV. On lists set to Send=Editor, editors are allowed to post directly to the list without moderation/approval."
+                },
+                {
+                    description: "Another Sync Dest",
+                    hidden: false,
+                    name: "other-sync",
+                    synced: false,
+                    tooltip: "This tooltip does not have the LISTSERV text"
+                }
+            ];
+            spyOn(gs, "getGroupingSyncDest").and.callFake((path, onSuccess, onError) => {
+                onSuccess({ syncDestinations: mockSyncDestinations });
+            });
+        });
+
+        it("should populate syncDestArray with sync destinations", (done) => {
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                expect(scope.syncDestArray.length).toBe(3);
+                expect(scope.syncDestArray[0].name).toBe("google-sync");
+                expect(scope.syncDestArray[1].name).toBe("listserv-sync");
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should trim tooltips containing 'On lists set to Send=Editor'", (done) => {
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // First tooltip should be trimmed
+                expect(scope.syncDestArray[0].tooltip).toBe("Synchronize with Google Groups.");
+                // Second tooltip should also be trimmed
+                expect(scope.syncDestArray[1].tooltip).toBe("Synchronize with LISTSERV.");
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should not modify tooltips without 'On lists set to Send=Editor'", (done) => {
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                expect(scope.syncDestArray[2].tooltip).toBe("This tooltip does not have the LISTSERV text");
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should call gs.getGroupingSyncDest with correct parameters", (done) => {
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                expect(gs.getGroupingSyncDest).toHaveBeenCalledWith(mockGroupPath, jasmine.any(Function), jasmine.any(Function));
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should call initSyncStatuses after populating syncDestArray", (done) => {
+            spyOn(scope, "initSyncStatuses").and.callThrough();
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                expect(scope.initSyncStatuses).toHaveBeenCalled();
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should handle tooltip with multiple occurrences of 'On lists set to Send=Editor'", (done) => {
+            mockSyncDestinations[0].tooltip = "First part. On lists set to Send=Editor, text1. On lists set to Send=Editor, text2";
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // Should only trim the first occurrence and everything after it
+                expect(scope.syncDestArray[0].tooltip).toBe("First part.");
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should handle empty syncDestinations array", (done) => {
+            gs.getGroupingSyncDest.and.callFake((path, onSuccess, onError) => {
+                onSuccess({ syncDestinations: [] });
+            });
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                expect(scope.syncDestArray.length).toBe(0);
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should trim whitespace after splitting tooltip", (done) => {
+            mockSyncDestinations[0].tooltip = "Description.   On lists set to Send=Editor, more text";
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // Should trim whitespace after split
+                expect(scope.syncDestArray[0].tooltip).toBe("Description.");
+                done();
+            });
+            scope.$apply();
+        });
+    });
+
+    describe("Sync Destination Tooltip Modal Display", () => {
+        let mockGroupPath;
+        let mockSyncDestinations;
+
+        beforeEach(() => {
+            mockGroupPath = "test-grouping-path";
+            mockSyncDestinations = [
+                {
+                    description: "Google-Group: #uh-iam-group",
+                    hidden: false,
+                    name: "google-sync",
+                    synced: false,
+                    tooltip: "Synchronize with Google Groups. On lists set to Send=Editor, editors are allowed to post directly to the list without moderation/approval."
+                },
+                {
+                    description: "LISTSERV List: #uh-listserv",
+                    hidden: false,
+                    name: "listserv-sync",
+                    synced: true,
+                    tooltip: "Synchronize with LISTSERV. On lists set to Send=Editor, editors are allowed to post directly to the list without moderation/approval."
+                }
+            ];
+            spyOn(gs, "getGroupingSyncDest").and.callFake((path, onSuccess, onError) => {
+                onSuccess({ syncDestinations: mockSyncDestinations });
+            });
+            spyOn(scope, "displayDynamicModal");
+        });
+
+        it("should display trimmed tooltip when user clicks question mark icon", (done) => {
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // Simulate user clicking the question mark icon for the first sync destination
+                const trimmedTooltip = scope.syncDestArray[0].tooltip;
+
+                // Call displayDynamicModal as the UI would
+                scope.displayDynamicModal("Sync Destinations Information", trimmedTooltip);
+
+                // Verify the trimmed tooltip (without LISTSERV text) was passed to the modal
+                expect(scope.displayDynamicModal).toHaveBeenCalledWith(
+                    "Sync Destinations Information",
+                    "Synchronize with Google Groups."
+                );
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should not include 'On lists set to Send=Editor' text in modal display", (done) => {
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                const firstSyncDestTooltip = scope.syncDestArray[0].tooltip;
+
+                // Verify the LISTSERV text is not in the tooltip
+                expect(firstSyncDestTooltip).not.toContain("On lists set to Send=Editor");
+                expect(firstSyncDestTooltip).not.toContain("editors are allowed to post");
+
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should display all sync destinations with trimmed tooltips", (done) => {
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                // Verify all sync destinations have trimmed tooltips
+                scope.syncDestArray.forEach(syncDest => {
+                    if (syncDest.tooltip && syncDest.tooltip.includes("Synchronize")) {
+                        expect(syncDest.tooltip).not.toContain("On lists set to Send=Editor");
+                    }
+                });
+                done();
+            });
+            scope.$apply();
+        });
+
+        it("should preserve non-LISTSERV tooltip text for display", (done) => {
+            // Add a sync destination without LISTSERV text
+            mockSyncDestinations.push({
+                description: "Custom Sync",
+                hidden: false,
+                name: "custom-sync",
+                synced: false,
+                tooltip: "Custom sync destination tooltip"
+            });
+
+            scope.getGroupingSyncDest(mockGroupPath).then(() => {
+                const customSyncTooltip = scope.syncDestArray[2].tooltip;
+                expect(customSyncTooltip).toBe("Custom sync destination tooltip");
+                scope.displayDynamicModal("Sync Destinations Information", customSyncTooltip);
+
+                expect(scope.displayDynamicModal).toHaveBeenCalledWith(
+                    "Sync Destinations Information",
+                    "Custom sync destination tooltip"
+                );
+                done();
+            });
+            scope.$apply();
+        });
+    });
+
     describe("displayOwnerErrorModal", () => {
         it("should set loading to false", () => {
             scope.loading = true;


### PR DESCRIPTION
# Ticket Link

[Ticket](https://uhawaii.atlassian.net/jira/software/c/projects/GROUPINGS/boards/18?quickFilter=75&selectedIssue=GROUPINGS-2184&useStoredSettings=true)

# List of squashed commits

- fixed the issue with too much complexity in grouping.controller.test.js
- fixed display of sync destination tooltip description and added tests


# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Jasmine Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
- [x] Checked For ADA Compliance:
