### PR TITLE
Fix Add Admin not blocking invalid UH usernames

### DIFF
--- a/src/main/resources/static/javascript/mainApp/admin.controller.js
+++ b/src/main/resources/static/javascript/mainApp/admin.controller.js
@@ -269,8 +269,11 @@
 
             groupingsService.getMemberAttributeResults([sanitizedAdmin], (res) => {
                 const members = res.results ?? [];
+                const invalidMembers = res.invalid ?? [];
                 $scope.containsDeptAcc = false;
                 $scope.containsServiceAccAdmin = false;
+                $scope.addInputError = false;
+                $scope.invalidMembers = [];
 
                 // Service accounts and department accounts are never eligible for admin assignment.
                 // Also treat leading "_" on the entered id as a service account: lookup may return empty or
@@ -278,6 +281,11 @@
                 const isServiceByEnteredId = _.isString(sanitizedAdmin) && sanitizedAdmin.startsWith("_");
                 if (isServiceByEnteredId || $scope.checkForServiceAccountMembers(members)) {
                     $scope.containsServiceAccAdmin = true;
+                    return;
+                }
+                if (!_.isEmpty(invalidMembers) || _.isEmpty(members)) {
+                    $scope.invalidMembers = _.isEmpty(invalidMembers) ? [sanitizedAdmin] : invalidMembers;
+                    $scope.addInputError = true;
                     return;
                 }
                 if ($scope.checkForDeptAccount(members)) {

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -147,6 +147,7 @@
             $scope.containsServiceAccAdmin = false;
             $scope.addInputError = false;
             $scope.removeInputError = false;
+            $scope.invalidMembers = [];
         };
 
         /**

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -133,7 +133,7 @@
                         <div class="col-lg-7">
                             <form class="d-flex" ng-submit="addAdmin()">
                                 <div class="w-75 input-group">
-                                    <input name="Add Admin" class="form-control" type="search"
+                                    <input name="AddAdmin" class="form-control" type="search"
                                            ng-init="dismissErrors()"
                                            ng-blur="dismissErrors()"
                                            title="Enter UH Username or UH Number"
@@ -173,7 +173,7 @@
                         <div class="mr-auto col-lg-3 col-md-4 col-12 p-0">
                             <form ng-submit="searchForUserGroupingInformation(); errorDismissed = false;">
                                 <div class="input-group">
-                                    <input name="Search Person" class="form-control" type="search" aria-required="true"
+                                    <input name="SearchPerson" class="form-control" type="search" aria-required="true"
                                            title="Enter UH Username" aria-label="Enter UH Username to manage the person"
                                            placeholder="UH Username" ng-model="subjectToLookup"
                                            ng-init="dismissErrors()"

--- a/src/main/resources/templates/fragments/add-error-messages.html
+++ b/src/main/resources/templates/fragments/add-error-messages.html
@@ -16,7 +16,7 @@
         <div ng-if="addInputError"
              class="float-md-left my-3 px-3 pt-2 h-50 rounded alert-danger show">
             <p>
-                <span class="alert-danger" th:text="#{screen.message.modal.add.fail}"></span>
+                <span class="alert-danger" th:text="#{screen.message.modal.add.fail}"></span><span>&nbsp;</span>
                 <span class="alert-danger" ng-repeat="members in invalidMembers">{{members}}{{$last ? "" : ", "}}</span>
             </p>
             <p th:text="#{screen.message.modal.add.ensureValid}"></p>

--- a/src/main/resources/templates/fragments/admin-error-messages.html
+++ b/src/main/resources/templates/fragments/admin-error-messages.html
@@ -14,6 +14,16 @@
             <p th:text="#{screen.message.modal.search.fail}"></p>
             <p th:text="#{screen.message.modal.search.ensureValid}"></p>
         </div>
+        <!--message for invalid input when adding-->
+        <div ng-if="addInputError"
+             class="float-md-left my-3 px-3 pt-2 rounded alert-danger show"
+             role="alert">
+            <p>
+                <span class="alert-danger" th:text="#{screen.message.modal.add.fail}"></span><span>&nbsp;</span>
+                <span class="alert-danger" ng-repeat="members in invalidMembers">{{members}}{{$last ? "" : ", "}}</span>
+            </p>
+            <p th:text="#{screen.message.modal.add.ensureValid}"></p>
+        </div>
         <!--message for adding an uhIdentifier that is already an admin-->
         <div ng-if="containsInput"
              class="float-md-left my-3 px-3 pt-2 rounded alert-danger show"

--- a/src/test/javascript/admin.controller.test.js
+++ b/src/test/javascript/admin.controller.test.js
@@ -524,6 +524,40 @@ describe("AdminController", function () {
             expect(scope.displayAddModal).not.toHaveBeenCalled();
         });
 
+        it("should show an add input error when the admin to add is invalid", () => {
+            spyOn(scope, "displayAddModal");
+            scope.addInputError = false;
+            scope.invalidMembers = [];
+            scope.adminToAdd = "word";
+            scope.addAdmin();
+
+            // Covers the normal /members invalid response shape.
+            const invalidResult = { resultCode: "SUCCESS", invalid: ["word"], results: [] };
+            httpBackend.expectPOST(BASE_URL + "members", ["word"]).respond(200, invalidResult);
+            httpBackend.flush();
+
+            expect(scope.addInputError).toBeTrue();
+            expect(scope.invalidMembers).toEqual(["word"]);
+            expect(scope.displayAddModal).not.toHaveBeenCalled();
+        });
+
+        it("should show an add input error when lookup returns no member row", () => {
+            spyOn(scope, "displayAddModal");
+            scope.addInputError = false;
+            scope.invalidMembers = [];
+            scope.adminToAdd = "12312312";
+            scope.addAdmin();
+
+            // Covers lookups that return 200 OK but no usable member row.
+            const emptyResults = { resultCode: "SUCCESS", invalid: [], results: [] };
+            httpBackend.expectPOST(BASE_URL + "members", ["12312312"]).respond(200, emptyResults);
+            httpBackend.flush();
+
+            expect(scope.addInputError).toBeTrue();
+            expect(scope.invalidMembers).toEqual(["12312312"]);
+            expect(scope.displayAddModal).not.toHaveBeenCalled();
+        });
+
         it("should display the add modal", () => {
             spyOn(scope, "displayAddModal");
             scope.adminToAdd = "testiwta";


### PR DESCRIPTION
# Ticket Link

[Ticket](https://uhawaii.atlassian.net/browse/GROUPINGS-2198)

# List of squashed commits

- Resolve HTML input name issue
- Prevent stale invalid add-admin identifiers from appearing after errors are dismissed
- Add logic to ensure that input error is flagged
- Add tests

# Test Checklist

- [X] Exhibits Clear Code Structure:
- [X] Project Unit Tests Passed:
- [X] Project Jasmine Tests Passed:
- [X] Executes Expected Functionality:
- [X] Tested For Incorrect/Unexpected Inputs:
- [X] Checked For ADA Compliance:
