### PR TITLE
Prevent stack dump when removing all direct owners

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestController.java
@@ -688,10 +688,10 @@ public class GroupingsRestController {
     /**
      * Get the number of owners of the group path that contains the owner with uhIdentifier
      */
-    @GetMapping(value = "/{path:.+}/owners/count")
-    public ResponseEntity<String> getNumberOfOwners(@PathVariable String path) {
+    @GetMapping(value = "/members/{path:.+}/owners/count")
+    public ResponseEntity<String> getNumberOfDirectOwners(@PathVariable String path) {
         String currentUid = policy.sanitize(userContextService.getCurrentUid());
-        logger.info(String.format("Entered REST getNumberOfOwners - currentUid: %s, path: %s",
+        logger.info(String.format("Entered REST getNumberOfDirectOwners - currentUid: %s, path: %s",
                 currentUid, path));
         String safePath = policy.sanitize(path);
         String baseUri = String.format(API_2_1_BASE + "/members/%s/owners/count", safePath);

--- a/src/main/resources/static/javascript/mainApp/admin.controller.js
+++ b/src/main/resources/static/javascript/mainApp/admin.controller.js
@@ -160,7 +160,7 @@
                 $scope.removeFromGroupsCallbackOnSuccess(memberToRemove);
             }
             _.forEach($scope.selectedOwnedGroupings, (grouping) => {
-                    groupingsService.getNumberOfOwners(grouping.path, (res) => {
+                    groupingsService.getNumberOfDirectOwners(grouping.path, (res) => {
                         if (res === 1) {
                             $scope.soleOwnerGroupingNames.push(grouping.name);
                         }

--- a/src/main/resources/static/javascript/mainApp/groupingDetails.controller.js
+++ b/src/main/resources/static/javascript/mainApp/groupingDetails.controller.js
@@ -60,6 +60,7 @@
         $scope.pagedItemsOwners = [];
         $scope.currentPageOwners = 0;
         $scope.ownerLimit = 0;
+        $scope.directOwnersCount = 0;
 
         $scope.allowOptIn = false;
         $scope.allowOptOut = false;
@@ -296,6 +297,13 @@
                     const immediateOwnersCount = $scope.groupingOwners.length;
                     let totalOwnerGroupingMembers = 0;
                     const jobs = [];
+                    let directOwnersCount = 0;
+                    const directOwnersCountJob = new Promise((r) => {
+                        groupingsService.getNumberOfDirectOwners(groupPath, (n) => {
+                            directOwnersCount = n;
+                            r();
+                        });
+                    });
                     let allOwnersCount = 0;
                     const allOwnersCountJob = new Promise((r) => {
                         groupingsService.getNumberOfAllOwners(groupPath, (n) => {
@@ -321,7 +329,8 @@
                             );
                         }
                     });
-                    await Promise.all([...jobs, allOwnersCountJob]);
+                    await Promise.all([...jobs, allOwnersCountJob, directOwnersCountJob]);
+                    $scope.directOwnersCount = directOwnersCount;
                     $scope.allOwnersCount = allOwnersCount;
                     $scope.hasDuplicateOwners = (immediateOwnersCount + totalOwnerGroupingMembers) !== $scope.allOwnersCount;
                     $scope.filter($scope.groupingOwners, "pagedItemsOwners", "currentPageOwners", $scope.ownersQuery, false);
@@ -1286,7 +1295,7 @@
             }
 
             // Prevent removing all owners
-            if ((listName === "owners") && $scope.multiRemoveResults.length === $scope.groupingOwners.length) {
+            if ((listName === "owners") && $scope.multiRemoveResults.length === $scope.directOwnersCount) {
                 $scope.displayRemoveErrorModal("owner");
                 clearMemberInput();
                 return;
@@ -1487,7 +1496,7 @@
             const ownerToRemove = $scope.pagedItemsOwners[Number(currentPage)][Number(index)];
             $scope.listName = "owners";
 
-            if ($scope.groupingOwners.length === 1) {
+            if ($scope.directOwnersCount === 1) {
                 $scope.displayRemoveErrorModal("owner");
                 return;
             }

--- a/src/main/resources/static/javascript/mainApp/groupingDetails.controller.js
+++ b/src/main/resources/static/javascript/mainApp/groupingDetails.controller.js
@@ -1294,7 +1294,7 @@
                 return;
             }
 
-            // Prevent removing all owners
+            // Prevent removing the last direct owner
             if ((listName === "owners") && $scope.multiRemoveResults.length === $scope.directOwnersCount) {
                 $scope.displayRemoveErrorModal("owner");
                 clearMemberInput();
@@ -1496,6 +1496,7 @@
             const ownerToRemove = $scope.pagedItemsOwners[Number(currentPage)][Number(index)];
             $scope.listName = "owners";
 
+            // Ensure that the owner being removed is not the last remaining direct owner.
             if ($scope.directOwnersCount === 1) {
                 $scope.displayRemoveErrorModal("owner");
                 return;

--- a/src/main/resources/static/javascript/mainApp/groupings.service.js
+++ b/src/main/resources/static/javascript/mainApp/groupings.service.js
@@ -444,7 +444,7 @@
             /**
              * Checks if the owner of a grouping is the sole owner
              */
-            getNumberOfOwners(path, onSuccess, onError) {
+            getNumberOfDirectOwners(path, onSuccess, onError) {
                 let endpoint = BASE_URL + path + "/owners/count";
                 dataProvider.loadData(endpoint, onSuccess, onError);
             },

--- a/src/main/resources/static/javascript/mainApp/groupings.service.js
+++ b/src/main/resources/static/javascript/mainApp/groupings.service.js
@@ -445,7 +445,7 @@
              * Checks if the owner of a grouping is the sole owner
              */
             getNumberOfDirectOwners(path, onSuccess, onError) {
-                let endpoint = BASE_URL + path + "/owners/count";
+                let endpoint = BASE_URL + "members/" + path + "/owners/count";
                 dataProvider.loadData(endpoint, onSuccess, onError);
             },
 

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerTest.java
@@ -929,8 +929,8 @@ public class GroupingsRestControllerTest {
 
     @Test
     @WithMockUhUser
-    public void getNumberOfOwners() throws Exception {
-        String uri = REST_CONTROLLER_BASE + GROUPING + "/owners/count";
+    public void getNumberOfDirectOwners() throws Exception {
+        String uri = REST_CONTROLLER_BASE + "members/" + GROUPING + "/owners/count";
 
         given(httpRequestService.makeApiRequest(anyString(), eq(HttpMethod.GET)))
                 .willReturn(new ResponseEntity(HttpStatus.OK));

--- a/src/test/javascript/groupingDetails.controller.test.js
+++ b/src/test/javascript/groupingDetails.controller.test.js
@@ -2080,6 +2080,26 @@ describe("GroupingController", () => {
                 uhUuid: "iamtst03"
             }];
             scope.manageMembers = "iamtst03";
+            scope.directOwnersCount = 1;
+            spyOn(scope, "displayRemoveErrorModal");
+            scope.removeMembers("owners");
+            expect(scope.displayRemoveErrorModal).toHaveBeenCalled();
+        });
+
+        it("should call displayRemoveErrorModal when the listName is owners and there's only one direct owner left", () => {
+            scope.groupingOwners = [
+                {
+                    name: "iamtst03",
+                    uid: "iamtst03",
+                    uhUuid: "iamtst03"
+                },
+                {
+                    name: "testOwnerGrouping",
+                    ownerGroupingPath: "test-owner-path"
+                }
+            ];
+            scope.manageMembers = "iamtst03";
+            scope.directOwnersCount = 1;
             spyOn(scope, "displayRemoveErrorModal");
             scope.removeMembers("owners");
             expect(scope.displayRemoveErrorModal).toHaveBeenCalled();
@@ -2324,12 +2344,13 @@ describe("GroupingController", () => {
             expect(scope.displayRemoveModal).toHaveBeenCalled();
         });
 
-        it("should display the remove error modal if groupingOwners < 1", () => {
+        it("should display the remove error modal if directOwnersCount is 1", () => {
             scope.groupingOwners = [{
                 name: "iamtst01",
                 uid: "iamtst01",
                 uhUuid: "iamtst01"
             }];
+            scope.directOwnersCount = 1;
             spyOn(scope, "displayRemoveErrorModal");
             scope.removeOwnerWithTrashcan(0, 0);
             expect(scope.displayRemoveErrorModal).toHaveBeenCalledWith("owner");


### PR DESCRIPTION
# [Groupings-2161, Prevent Stack Dump When Removing All Direct Owners](https://uhawaii.atlassian.net/browse/GROUPINGS-2161)

[Ticket](https://uhawaii.atlassian.net/browse/GROUPINGS-2161)

# List of squashed commits

- Reworked last owner removal logic and tests
- Fixed Endpoints
- Added Comments to clarify changes


# Test Checklist

- [X] Exhibits Clear Code Structure:
- [X] Project Unit Tests Passed:
- [X] Project Jasmine Tests Passed:
- [X] Executes Expected Functionality:
- [X] Tested For Incorrect/Unexpected Inputs:
- [X] Checked For ADA Compliance:
