### PR TITLE
Ensure the filter for groupings function is applied only to currently displayed columns

### DIFF
--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -217,6 +217,16 @@
             localStorage.setItem("columnDisplaySetting", $scope.columnDisplaySetting);
             localStorage.setItem("showDescriptionColumn", JSON.stringify($scope.showDescriptionColumn));
             localStorage.setItem("showPathColumn", JSON.stringify($scope.showGroupingPathColumn));
+
+            if (_.isArray($scope.groupingsList)) {
+                $scope.filter(
+                    $scope.groupingsList,
+                    "pagedItemsGroupings",
+                    "currentPageGroupings",
+                    $scope.groupingsQuery,
+                    true
+                );
+            }
         };
 
         /**

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -218,15 +218,14 @@
             localStorage.setItem("showDescriptionColumn", JSON.stringify($scope.showDescriptionColumn));
             localStorage.setItem("showPathColumn", JSON.stringify($scope.showGroupingPathColumn));
 
-            if (_.isArray($scope.groupingsList)) {
-                $scope.filter(
-                    $scope.groupingsList,
-                    "pagedItemsGroupings",
-                    "currentPageGroupings",
-                    $scope.groupingsQuery,
-                    true
-                );
-            }
+            const refilterIfPresent = (listVar, pagedListVar, pageVar, query) => {
+                if (_.isArray($scope[listVar])) {
+                    $scope.filter($scope[listVar], pagedListVar, pageVar, query, true);
+                }
+            };
+            refilterIfPresent("groupingsList", "pagedItemsGroupings", "currentPageGroupings", $scope.groupingsQuery);
+            refilterIfPresent("membershipsList", "pagedItemsMemberships", "currentPageMemberships", $scope.membersQuery);
+            refilterIfPresent("optInList", "pagedItemsOptInList", "currentPageOptIn", $scope.optInQuery);
         };
 
         /**

--- a/src/main/resources/static/javascript/mainApp/general.controller.js
+++ b/src/main/resources/static/javascript/mainApp/general.controller.js
@@ -218,14 +218,14 @@
             localStorage.setItem("showDescriptionColumn", JSON.stringify($scope.showDescriptionColumn));
             localStorage.setItem("showPathColumn", JSON.stringify($scope.showGroupingPathColumn));
 
-            const refilterIfPresent = (listVar, pagedListVar, pageVar, query) => {
-                if (_.isArray($scope[listVar])) {
-                    $scope.filter($scope[listVar], pagedListVar, pageVar, query, true);
+            const refilterIfPresent = (list, pagedListVar, pageVar, query) => {
+                if (_.isArray(list)) {
+                    $scope.filter(list, pagedListVar, pageVar, query, true);
                 }
             };
-            refilterIfPresent("groupingsList", "pagedItemsGroupings", "currentPageGroupings", $scope.groupingsQuery);
-            refilterIfPresent("membershipsList", "pagedItemsMemberships", "currentPageMemberships", $scope.membersQuery);
-            refilterIfPresent("optInList", "pagedItemsOptInList", "currentPageOptIn", $scope.optInQuery);
+            refilterIfPresent($scope.groupingsList, "pagedItemsGroupings", "currentPageGroupings", $scope.groupingsQuery);
+            refilterIfPresent($scope.membershipsList, "pagedItemsMemberships", "currentPageMemberships", $scope.membersQuery);
+            refilterIfPresent($scope.optInList, "pagedItemsOptInList", "currentPageOptIn", $scope.optInQuery);
         };
 
         /**

--- a/src/main/resources/static/javascript/mainApp/table.controller.js
+++ b/src/main/resources/static/javascript/mainApp/table.controller.js
@@ -56,6 +56,12 @@
          * otherwise returns true.
          */
         const isFilterableColumn = (key) => {
+            if (key === "description") {
+                return $scope.showDescriptionColumn;
+            }
+            if (key === "path") {
+                return $scope.showGroupingPathColumn;
+            }
             return !_.includes(FILTER_COLUMNS_TO_IGNORE, key);
         };
 

--- a/src/test/javascript/general.controller.test.js
+++ b/src/test/javascript/general.controller.test.js
@@ -469,6 +469,22 @@ describe("GeneralController", () => {
             expect(localStorage.getItem("showDescriptionColumn")).toBe("true");
             expect(localStorage.getItem("showPathColumn")).toBe("true");
         });
+
+        it("should refilter groupings when switching displayed columns", () => {
+            scope.groupingsList = [{ name: "grouping" }];
+            scope.groupingsQuery = "test query";
+            spyOn(scope, "filter");
+
+            scope.showColumn("groupingPath");
+
+            expect(scope.filter).toHaveBeenCalledWith(
+                scope.groupingsList,
+                "pagedItemsGroupings",
+                "currentPageGroupings",
+                scope.groupingsQuery,
+                true
+            );
+        });
     });
 
     describe("hoverCopy", () => {

--- a/src/test/javascript/table.controller.test.js
+++ b/src/test/javascript/table.controller.test.js
@@ -174,6 +174,38 @@ describe("TableController", () => {
             expect(scope.pagedItems.length).toEqual(0);
         });
 
+        it("should filter groupings by name and description when the path column is hidden", () => {
+            scope.items = [
+                { name: "name-match", description: "description", path: "path" },
+                { name: "name", description: "description-match", path: "path" },
+                { name: "name", description: "description", path: "path-match" }
+            ];
+            scope.showDescriptionColumn = true;
+            scope.showGroupingPathColumn = false;
+
+            scope.filter(scope.items, "pagedItems", "currentPage", "match", true);
+
+            expect(scope.pagedItems.length).toEqual(2);
+            expect(scope.pagedItems[0][0]).toEqual(scope.items[0]);
+            expect(scope.pagedItems[1][0]).toEqual(scope.items[1]);
+        });
+
+        it("should filter groupings by name and path when the description column is hidden", () => {
+            scope.items = [
+                { name: "name-match", description: "description", path: "path" },
+                { name: "name", description: "description-match", path: "path" },
+                { name: "name", description: "description", path: "path-match" }
+            ];
+            scope.showDescriptionColumn = false;
+            scope.showGroupingPathColumn = true;
+
+            scope.filter(scope.items, "pagedItems", "currentPage", "match", true);
+
+            expect(scope.pagedItems.length).toEqual(2);
+            expect(scope.pagedItems[0][0]).toEqual(scope.items[0]);
+            expect(scope.pagedItems[1][0]).toEqual(scope.items[2]);
+        });
+
         it("should call groupToPages so the table is repaginated", () => {
             spyOn(scope, "groupToPages").and.callThrough();
 


### PR DESCRIPTION
# Ticket Link

[Ticket](https://uhawaii.atlassian.net/jira/software/c/projects/GROUPINGS/boards/18?quickFilter=75&selectedIssue=GROUPINGS-2225&useStoredSettings=true)

# List of squashed commits

-  Made it so that it refilters the columns when switching filtering options.
- Fixed grouping table filtering for description and path

# Test Checklist

- [ ] Exhibits Clear Code Structure:
- [ ] Project Unit Tests Passed:
- [ ] Project Jasmine Tests Passed:
- [ ] Executes Expected Functionality:
- [ ] Tested For Incorrect/Unexpected Inputs:
- [ ] Checked For ADA Compliance:
